### PR TITLE
php.extenions.mysql: init

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,3 +54,7 @@ jobs:
       - name: Build Redis 3 extension
         if: ${{ matrix.php.major < 8 }}
         run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis3
+
+      - name: Build MySQL extension
+        if: ${{ matrix.php.major < 7 }}
+        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.mysql

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1624668028,
-        "narHash": "sha256-FUxvXMBPQ5jrGhS47jwBFZQte0yDkMCBI5M24mJi5X0=",
+        "lastModified": 1624966692,
+        "narHash": "sha256-zh8iJxPUTD2Br93HzVMfYoVef8HYlNDa2MaIeaeaKsg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e85975942742a3728226ac22a3415f2355bfc897",
+        "rev": "485d0fc9730a9e1d460e00af1d1becc541e2ad4f",
         "type": "github"
       },
       "original": {

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -112,6 +112,25 @@ in
       else
         prev.extensions.memcached;
 
+    mysql =
+      if lib.versionOlder prev.php.version "7.0" then
+        prev.mkExtension {
+          name = "mysql";
+          internalDeps = [ prev.php.extensions.mysqlnd ];
+          configureFlags = [
+            "--with-mysql"
+            "--with-mysql-sock=/run/mysqld/mysqld.sock"
+          ];
+          # Fix mysql not being able to find headers.
+          postPatch = ''
+            popd
+
+            ln -s $PWD/../../ext/ $PWD
+          '';
+        }
+      else
+        null;
+
     mysqlnd =
       if lib.versionOlder prev.php.version "7.1" then
         prev.extensions.mysqlnd.overrideAttrs (attrs: {


### PR DESCRIPTION
- packages the `mysql` extension for ancient applications which need it
- resolves #27
- **requires a pulling in a recent version of `nixpkgs` before this will work**