### PR TITLE
php56.extensions.mysqli,pdo_mysql: set default unix socket path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,3 +58,37 @@ jobs:
       - name: Build MySQL extension
         if: ${{ matrix.php.major < 7 }}
         run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.mysql
+
+      - name: Validate php.extensions.mysqli default unix socket path
+        run: |
+          nix-shell -E '
+            let
+              self = import ./.;
+              php =
+                self.outputs.packages.${builtins.currentSystem}.php${{ matrix.php.major }}${{ matrix.php.minor }}.withExtensions
+                  ({ all, ... }: [ all.mysqli ]);
+              pkgs = import self.inputs.nixpkgs { };
+            in
+              pkgs.mkShell {
+                packages = [
+                  php
+                ];
+              }
+          ' --run "php -r \"echo ini_get('mysqli.default_socket') . PHP_EOL;\" | grep /run/mysqld/mysqld.sock"
+
+      - name: Validate php.extensions.pdo_mysql default unix socket path
+        run: |
+          nix-shell -E '
+            let
+              self = import ./.;
+              php =
+                self.outputs.packages.${builtins.currentSystem}.php${{ matrix.php.major }}${{ matrix.php.minor }}.withExtensions
+                  ({ all, ... }: [ all.pdo_mysql ]);
+              pkgs = import self.inputs.nixpkgs { };
+            in
+              pkgs.mkShell {
+                packages = [
+                  php
+                ];
+              }
+          ' --run "php -r \"echo ini_get('pdo_mysql.default_socket') . PHP_EOL;\" | grep /run/mysqld/mysqld.sock"

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -188,6 +188,15 @@ in
       else
         prev.extensions.openssl;
 
+    pdo_mysql =
+      if lib.versionOlder prev.php.version "7.0" then
+        prev.extensions.pdo_mysql.overrideAttrs (attrs: {
+          # PHP_MYSQL_SOCK didn't exist in php 5.6
+          NIX_CFLAGS_COMPILE = "-DPDO_MYSQL_UNIX_ADDR=\"/run/mysqld/mysqld.sock\"";
+        })
+      else
+        prev.extensions.pdo_mysql;
+
     readline = prev.extensions.readline.overrideAttrs (attrs: {
       patches =
         let

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -131,6 +131,15 @@ in
       else
         null;
 
+    mysqli =
+      if lib.versionOlder prev.php.version "7.0" then
+        prev.extensions.mysqli.overrideAttrs (attrs: {
+          # the --with-mysql-sock option didn't exist in php 5.6
+          NIX_CFLAGS_COMPILE = "-DPHP_MYSQL_UNIX_SOCK_ADDR=\"/run/mysqld/mysqld.sock\"";
+        })
+      else
+        prev.extensions.mysqli;
+
     mysqlnd =
       if lib.versionOlder prev.php.version "7.1" then
         prev.extensions.mysqlnd.overrideAttrs (attrs: {


### PR DESCRIPTION
#### motivation ####
- the `--with-mysql-sock` option didn't exist in `php` 5.6

**before**
```
php -r "echo 'path: ' . ini_get('mysqli.default_socket') . PHP_EOL;"
path:
```

**after**
```
php -r "echo 'path: ' . ini_get('mysqli.default_socket') . PHP_EOL;"
path: /run/mysqld/mysqld.sock
```

The same is true for `pdo_mysql.default_socket`.