### PR TITLE
php56.extensions.mssql: init

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -112,6 +112,17 @@ in
       else
         prev.extensions.memcached;
 
+    mssql =
+      if lib.versionOlder prev.php.version "7.0" then
+        prev.mkExtension {
+          name = "mssql";
+          configureFlags = [
+            "--with-mssql=${pkgs.freetds}"
+          ];
+        }
+      else
+        null;
+
     mysql =
       if lib.versionOlder prev.php.version "7.0" then
         prev.mkExtension {


### PR DESCRIPTION
- packages the `mssql` extension for ancient applications which need it
- extension was available in prior versions of `nixpkgs`