### PR TITLE
Fix composer on PHP ≤ 7.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636798009,
-        "narHash": "sha256-TALPXFghk+V7GMYYlHMKXRHFR/7TdWL7i/dbtdU6dfA=",
+        "lastModified": 1637593665,
+        "narHash": "sha256-R7jKS7A+0tZS8qD5pBr1UFcMiTdsw5bfoxgXbYsoWhM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cae36cff14bfb48f9903143d393762b21357c33",
+        "rev": "98747f27ecfee70c8c97b195cbb94df80a074dda",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1634851050,
-        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {

--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -15,6 +15,15 @@ let
       # For passing pcre2 to generic.nix.
       pcre2 = if (prev.lib.versionAtLeast args.version "7.3") then prev.pcre2 else prev.pcre;
 
+      phpAttrsOverrides = attrs: {
+        configureFlags =
+          attrs.configureFlags
+          ++ prev.lib.optionalString (prev.lib.versionOlder args.version "7.4") [
+            # phar extension’s build system expects hash or it will degrade.
+            "--enable-hash"
+          ];
+      };
+
       # For passing pcre2 to php-packages.nix.
       callPackage =
         cpFn: cpArgs:
@@ -67,7 +76,7 @@ let
 in {
   php56 = base56.withExtensions ({ all, ... }: with all; ([
     bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-    gettext gmp hash iconv intl json ldap mbstring mysqli mysqlnd opcache
+    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
     openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
     posix readline session simplexml sockets soap sqlite3
     tokenizer xmlreader xmlwriter zip zlib
@@ -75,7 +84,7 @@ in {
 
   php70 = base70.withExtensions ({ all, ... }: with all; ([
     bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-    gettext gmp hash iconv intl json ldap mbstring mysqli mysqlnd opcache
+    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
     openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
     posix readline session simplexml sockets soap sqlite3
     tokenizer xmlreader xmlwriter zip zlib
@@ -83,7 +92,7 @@ in {
 
   php71 = base71.withExtensions ({ all, ... }: with all; ([
     bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-    gettext gmp hash iconv intl json ldap mbstring mysqli mysqlnd opcache
+    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
     openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
     posix readline session simplexml sockets soap sqlite3
     tokenizer xmlreader xmlwriter zip zlib
@@ -91,7 +100,7 @@ in {
 
   php72 = base72.withExtensions ({ all, ... }: with all; ([
     bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-    gettext gmp hash iconv intl json ldap mbstring mysqli mysqlnd opcache
+    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd opcache
     openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite pgsql
     posix readline session simplexml sockets soap sodium sqlite3
     tokenizer xmlreader xmlwriter zip zlib
@@ -99,7 +108,7 @@ in {
 
   php73 = base73.withExtensions ({ all, ... }: with all; ([
     bcmath calendar curl ctype dom exif fileinfo filter ftp gd
-    gettext gmp hash iconv intl json ldap mbstring mysqli mysqlnd
+    gettext gmp iconv intl json ldap mbstring mysqli mysqlnd
     opcache openssl pcntl pdo pdo_mysql pdo_odbc pdo_pgsql pdo_sqlite
     pgsql posix readline session simplexml sockets soap sodium sqlite3
     tokenizer xmlreader xmlwriter zip zlib


### PR DESCRIPTION
Composer 2.1.6 switched PHAR signatures to SHA512 (https://github.com/composer/composer/commit/e49f24e3550329913f5eb5e92669f403c9484a91). On older versions of PHP, support for SHA-256 and SHA-512 is conditional
on hash extension being enabled at compile time. Since we build hash extension in a separate package, phar extension assumes it will not be available and comments out the code paths, causing the following error

    Fatal error: Uncaught PharException: phar "/nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar" has a unsupported signature in /nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar:23
    Stack trace:
    #0 /nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar(23): Phar::mapPhar('composer.phar')
    #1 {main}
      thrown in /nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar on line 23

PHP ≥ 7.4 always bundles the hash extension (https://github.com/php/php-src/commit/033cafacbd8b184260c91a74ea7956b302857706) so it is not affected.

Depends on: https://github.com/NixOS/nixpkgs/pull/144564