### PR TITLE
Downgrade composer on PHP ≤ 7.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,6 +59,22 @@ jobs:
         if: ${{ matrix.php.major < 7 }}
         run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.mysql
 
+      - name: Check that composer PHAR works
+        run: |
+          nix-shell -E '
+            let
+              self = import ./.;
+              composer =
+                self.outputs.packages.${builtins.currentSystem}.php${{ matrix.php.major }}${{ matrix.php.minor }}.packages.composer;
+              pkgs = import self.inputs.nixpkgs { };
+            in
+              pkgs.mkShell {
+                packages = [
+                  composer
+                ];
+              }
+          ' --run "composer --version"
+
       - name: Validate php.extensions.mysqli default unix socket path
         run: |
           nix-shell -E '

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -14,6 +14,19 @@ in
 {
   tools = prev.tools // {
     php-cs-fixer-2 = final.callPackage ./php-cs-fixer/2.x.nix { };
+
+    # Downgrade composer to a version that builds with our PHP versions.
+    composer =
+      if lib.versionOlder prev.php.version "7.4" then
+        prev.tools.composer.overrideAttrs (attrs: rec {
+          version = "2.1.5";
+          src = pkgs.fetchurl {
+            url = "https://getcomposer.org/download/${version}/composer.phar";
+            sha256 = "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec";
+          };
+        })
+      else
+        prev.tools.composer;
   };
 
   extensions = prev.extensions // {


### PR DESCRIPTION
Composer 2.1.6 switched PHAR signatures to SHA512 (https://github.com/composer/composer/commit/e49f24e3550329913f5eb5e92669f403c9484a91). On older versions of PHP, support for SHA-256 and SHA-512 is conditional on `hash` extension being enabled at compile time. Since we build `hash` extension in a separate package, `phar` extension assumes it will not be available and comments out the code paths, causing the following error:

    Fatal error: Uncaught PharException: phar "/nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar" has a unsupported signature in /nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar:23
    Stack trace:
    #0 /nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar(23): Phar::mapPhar('composer.phar')
    #1 {main}
      thrown in /nix/store/rf48l2wpxqi3vfadf3vf1z3pq35p7d5i-php-composer-2.1.6/libexec/composer/composer.phar on line 23

PHP ≥ 7.4 always bundles the `hash` extension (https://github.com/php/php-src/commit/033cafacbd8b184260c91a74ea7956b302857706) so it is not affected.

Unfortunately, it is non-trivial to fix that so for now, let’s downgrade composer on affected PHP versions.
