### PR TITLE
feat: Add PHP81.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         php:
           - major: 8
+            minor: 1
+          - major: 8
             minor: 0
           - major: 7
             minor: 4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following versions are currently supported:
 - `php73`
 - `php74`
 - `php80`
+- `php81`
 
 There is also a `php` package which is the alias of the default PHP version in Nixpkgs.
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639837534,
-        "narHash": "sha256-zAZoVtvVfrs41e+kEEumyptQ4DOkcXQIYgxmaJ51+hs=",
+        "lastModified": 1640090545,
+        "narHash": "sha256-6qiF46uBGoSQmjDTFl8ilT+d1DuK39IRHlj0jE5gqZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1f9e754a40b645a39f6592d45df943cb5f59dcf",
+        "rev": "1dd151f0c0c216f416e9553af08f724a2499c795",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
         };
       in {
         packages = {
-          inherit (pkgs) php php56 php70 php71 php72 php73 php74 php80;
+          inherit (pkgs) php php56 php70 php71 php72 php73 php74 php80 php81;
         };
       }
     ) // {

--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -121,4 +121,8 @@ in {
   php80 = prev.php80.override {
     inherit packageOverrides;
   };
+
+  php81 = prev.php81.override {
+    inherit packageOverrides;
+  };
 }


### PR DESCRIPTION
PHP 8.1.1 has just been merged in Nixos (https://github.com/NixOS/nixpkgs/pull/147411).

This PR add support for PHP 8.1.1 in this package.

Tests are failing for now because `nixos-unstable` hasn't been updated yet.