### PR TITLE
php72.extensions.intl: Fix builds on Darwin.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,10 +9,13 @@ on:
 
 jobs:
   build:
-    name: 'PHP ${{ matrix.php.major }}.${{ matrix.php.minor }}'
-    runs-on: ubuntu-20.04
+    name: 'PHP ${{ matrix.php.major }}.${{ matrix.php.minor }} on ${{ matrix.operating-system }}'
+    runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
+        operating-system:
+          - ubuntu-latest
+          - macOS-latest
         php:
           - major: 8
             minor: 1
@@ -36,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v14
+        uses: cachix/install-nix-action@v16
 
       - name: Set up Nix cache
         uses: cachix/cachix-action@v10
@@ -45,31 +48,31 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build PHP
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}
 
       - name: Build Imagick extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.imagick
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.imagick
 
       - name: Build Redis extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis
 
       - name: Build Redis 3 extension
         if: ${{ matrix.php.major < 8 }}
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis3
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis3
 
       - name: Build MySQL extension
         if: ${{ matrix.php.major < 7 }}
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.mysql
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.mysql
 
       - name: Build Xdebug extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.xdebug
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.xdebug
 
       - name: Build Tidy extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.tidy
+        run: nix build .#php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.tidy
 
       - name: Check that composer PHAR works
         run: |
-          nix-shell -E '
+          nix develop --impure --expr '
             let
               self = import ./.;
               composer =
@@ -81,11 +84,11 @@ jobs:
                   composer
                 ];
               }
-          ' --run "composer --version"
+          ' -c composer --version
 
       - name: Validate php.extensions.mysqli default unix socket path
         run: |
-          nix-shell -E '
+          nix develop --impure --expr '
             let
               self = import ./.;
               php =
@@ -98,11 +101,11 @@ jobs:
                   php
                 ];
               }
-          ' --run "php -r \"echo ini_get('mysqli.default_socket') . PHP_EOL;\" | grep /run/mysqld/mysqld.sock"
+          ' -c php -r "echo ini_get('mysqli.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
 
       - name: Validate php.extensions.pdo_mysql default unix socket path
         run: |
-          nix-shell -E '
+          nix develop --impure --expr '
             let
               self = import ./.;
               php =
@@ -115,4 +118,4 @@ jobs:
                   php
                 ];
               }
-          ' --run "php -r \"echo ini_get('pdo_mysql.default_socket') . PHP_EOL;\" | grep /run/mysqld/mysqld.sock"
+          ' -c php -r "echo ini_get('pdo_mysql.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -104,6 +104,11 @@ in
                   patch "$out" < ${if lib.versionOlder prev.php.version "7.0" then ./patches/intl-icu-patch-5.6-compat.patch else ./patches/intl-icu-patch-7.0-compat.patch}
                 '';
               })
+            ] ++
+            lib.optionals (lib.versions.majorMinor prev.php.version == "7.2") [
+              # Fix compiling issue on Darwin platforms.
+              # See bug #76826: https://bugs.php.net/bug.php?id=76826
+              ./patches/bug76826.patch
             ];
         in
         ourPatches ++ upstreamPatches;

--- a/pkgs/patches/bug76826.patch
+++ b/pkgs/patches/bug76826.patch
@@ -1,0 +1,62 @@
+diff --git a/Zend/configure.ac b/Zend/configure.ac
+index b95c1360b8..fe16c86007 100644
+--- a/Zend/configure.ac
++++ b/Zend/configure.ac
+@@ -60,7 +60,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #include <math.h>
+
+ #ifndef zend_isnan
+-#if HAVE_DECL_ISNAN && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISNAN && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isnan(a) isnan(a)
+ #elif defined(HAVE_FPCLASS)
+ #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
+@@ -69,7 +69,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #endif
+ #endif
+
+-#if HAVE_DECL_ISINF && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISINF && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isinf(a) isinf(a)
+ #elif defined(INFINITY)
+ /* Might not work, but is required by ISO C99 */
+@@ -80,7 +80,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #define zend_isinf(a) 0
+ #endif
+
+-#if HAVE_DECL_ISFINITE && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISFINITE && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_finite(a) isfinite(a)
+ #elif defined(HAVE_FINITE)
+ #define zend_finite(a) finite(a)
+diff --git a/configure.ac b/configure.ac
+index d3f3cacd07..ddbf712ba2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -68,7 +68,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #include <math.h>
+
+ #ifndef zend_isnan
+-#if HAVE_DECL_ISNAN && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISNAN && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isnan(a) isnan(a)
+ #elif defined(HAVE_FPCLASS)
+ #define zend_isnan(a) ((fpclass(a) == FP_SNAN) || (fpclass(a) == FP_QNAN))
+@@ -77,7 +77,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #endif
+ #endif
+
+-#if HAVE_DECL_ISINF && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISINF && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_isinf(a) isinf(a)
+ #elif defined(INFINITY)
+ /* Might not work, but is required by ISO C99 */
+@@ -88,7 +88,7 @@ int zend_sprintf(char *buffer, const char *format, ...);
+ #define zend_isinf(a) 0
+ #endif
+
+-#if HAVE_DECL_ISFINITE && (!defined(__cplusplus) || __cplusplus < 201103L)
++#if HAVE_DECL_ISFINITE && (defined(__APPLE__) || defined(__APPLE_CC__) || !defined(__cplusplus) || __cplusplus < 201103L)
+ #define zend_finite(a) isfinite(a)
+ #elif defined(HAVE_FINITE)
+ #define zend_finite(a) finite(a)


### PR DESCRIPTION
It seems that it is not possible to build PHP with Intl extension on Darwin platform.

See: https://github.com/loophp/nix-shell/runs/5142961981?check_suite_focus=true

This patch should fix the issue.

PS: I don't have any Mac to test this.