### PR TITLE
Move checks into the flake

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,74 +45,33 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build PHP
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-php
 
       - name: Build Imagick extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.imagick
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-imagick
 
       - name: Build Redis extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-redis
 
       - name: Build Redis 3 extension
         if: ${{ matrix.php.major < 8 }}
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.redis3
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-redis3
 
       - name: Build MySQL extension
         if: ${{ matrix.php.major < 7 }}
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.mysql
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-mysql
 
       - name: Build Xdebug extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.xdebug
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-xdebug
 
       - name: Build Tidy extension
-        run: nix-build -A outputs.packages.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}.extensions.tidy
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-tidy
 
       - name: Check that composer PHAR works
-        run: |
-          nix-shell -E '
-            let
-              self = import ./.;
-              composer =
-                self.outputs.packages.${builtins.currentSystem}.php${{ matrix.php.major }}${{ matrix.php.minor }}.packages.composer;
-              pkgs = import self.inputs.nixpkgs { };
-            in
-              pkgs.mkShell {
-                packages = [
-                  composer
-                ];
-              }
-          ' --run "composer --version"
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-composer-phar
 
       - name: Validate php.extensions.mysqli default unix socket path
-        run: |
-          nix-shell -E '
-            let
-              self = import ./.;
-              php =
-                self.outputs.packages.${builtins.currentSystem}.php${{ matrix.php.major }}${{ matrix.php.minor }}.withExtensions
-                  ({ all, ... }: [ all.mysqli ]);
-              pkgs = import self.inputs.nixpkgs { };
-            in
-              pkgs.mkShell {
-                packages = [
-                  php
-                ];
-              }
-          ' --run "php -r \"echo ini_get('mysqli.default_socket') . PHP_EOL;\" | grep /run/mysqld/mysqld.sock"
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-mysqli-socket-path
 
       - name: Validate php.extensions.pdo_mysql default unix socket path
-        run: |
-          nix-shell -E '
-            let
-              self = import ./.;
-              php =
-                self.outputs.packages.${builtins.currentSystem}.php${{ matrix.php.major }}${{ matrix.php.minor }}.withExtensions
-                  ({ all, ... }: [ all.pdo_mysql ]);
-              pkgs = import self.inputs.nixpkgs { };
-            in
-              pkgs.mkShell {
-                packages = [
-                  php
-                ];
-              }
-          ' --run "php -r \"echo ini_get('pdo_mysql.default_socket') . PHP_EOL;\" | grep /run/mysqld/mysqld.sock"
+        run: nix-build -A outputs.checks.x86_64-linux.php${{ matrix.php.major }}${{ matrix.php.minor }}-pdo_mysql-socket-path

--- a/checks.nix
+++ b/checks.nix
@@ -1,0 +1,160 @@
+{
+  system,
+  packages,
+  pkgs,
+}:
+
+let
+  phpPackages = builtins.filter (name: builtins.match "php[0-9]+" name != null) (builtins.attrNames packages);
+
+  checks = {
+    php = {
+      description = "Build PHP";
+      drv = { php, ... }: php;
+    };
+
+    imagick = {
+      description = "Build Imagick extension";
+      drv = { php, ... }: php.extensions.imagick;
+    };
+
+    redis = {
+      description = "Build Redis extension";
+      drv = { php, ... }: php.extensions.redis;
+    };
+
+    redis3 = {
+      description = "Build Redis 3 extension";
+      enabled = { php, lib, ... }: lib.versionOlder php.version "8";
+      drv = { php, ... }: php.extensions.redis3;
+    };
+
+    mysql = {
+      description = "Build MySQL extension";
+      enabled = { php, lib, ... }: lib.versionOlder php.version "7";
+      drv = { php, ... }: php.extensions.mysql;
+    };
+
+    xdebug = {
+      description = "Build Xdebug extension";
+      drv = { php, ... }: php.extensions.xdebug;
+    };
+
+    tidy = {
+      description = "Build Tidy extension";
+      drv = { php, ... }: php.extensions.tidy;
+    };
+
+    composer-phar = {
+      description = "Check that composer PHAR works";
+      drv =
+        { pkgs, php, ... }:
+        pkgs.runCommand
+          "composer-phar-check"
+          {
+            buildInputs = [
+              php.packages.composer
+            ];
+          }
+          ''
+            composer --version
+            touch "$out"
+          '';
+    };
+
+    mysqli-socket-path = {
+      description = "Validate php.extensions.mysqli default unix socket path";
+      drv =
+        { pkgs, php, ... }:
+        pkgs.runCommand
+          "mysqli-socket-path-check"
+          {
+            buildInputs = [
+              (php.withExtensions ({ all, ... }: [
+                all.mysqli
+              ]))
+            ];
+          }
+          ''
+            php -r "echo ini_get('mysqli.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
+            touch "$out"
+          '';
+    };
+
+    pdo_mysql-socket-path = {
+      description = "Validate php.extensions.pdo_mysql default unix socket path";
+      drv =
+        { pkgs, php, ... }:
+        pkgs.runCommand
+          "pdo_mysql-socket-path-check"
+          {
+            buildInputs = [
+              (php.withExtensions ({ all, ... }: [
+                all.pdo_mysql
+              ]))
+            ];
+          }
+          ''
+            php -r "echo ini_get('pdo_mysql.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
+            touch "$out"
+          '';
+    };
+  };
+
+  inherit (pkgs) lib;
+
+  /* AttrSet<phpName, AttrSet<checkName, checkDrv>> */
+  checksPerVersion =
+    lib.listToAttrs (
+      builtins.map
+        (phpName:
+          let
+            php = packages.${phpName};
+            phpVersion = lib.versions.majorMinor php.version;
+            args = { inherit lib php pkgs system; };
+            supportedChecks = lib.filterAttrs (_name: { enabled ? lib.const true, ... }: enabled args) checks;
+          in
+          {
+            name = phpName;
+            value =
+              lib.mapAttrs
+                (
+                  _name:
+                  {
+                    description,
+                    drv,
+                    ...
+                  }:
+
+                  let
+                    check = drv args;
+                  in
+                  check // {
+                    passthru = check.passthru or { } // {
+                      description = "PHP ${phpVersion} – ${description}";
+                    };
+                  }
+                )
+                supportedChecks;
+          }
+        )
+        phpPackages
+    );
+in
+lib.foldAttrs
+  lib.mergeAttrs
+  {}
+  (
+    lib.mapAttrsToList
+    (
+      phpName:
+
+      lib.mapAttrs'
+        (
+          name:
+
+          lib.nameValuePair "${phpName}-${name}"
+        )
+    )
+    checksPerVersion
+  )

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,13 @@
             self.overlay
           ];
         };
-      in {
+      in rec {
         packages = {
           inherit (pkgs) php php56 php70 php71 php72 php73 php74 php80 php81;
+        };
+
+        checks = import ./checks.nix {
+          inherit packages pkgs system;
         };
       }
     ) // {


### PR DESCRIPTION
This will make it easier to run checks locally (e.g. using `nix flake check`). Additionally, it will allow us to generate the CI tasks automatically and support different sets of checks for different platforms easily.
