### PR TITLE
flake: Update & re-introduce checks removed in Nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652114896,
-        "narHash": "sha256-PUTs4A2ZPUWi6P2p6p4avgYiOWaVkOA9CrgiSH6XPNg=",
+        "lastModified": 1652637578,
+        "narHash": "sha256-c1A4IPkFD+OCfbz0NXDEY1r2Nhm67aPZRmsvEve7GFI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4ae23f5c7d5f291a22726625aff2a961fcf12dab",
+        "rev": "ea69f79829972187ecf6c1eaede4ce7a15d81736",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1652557277,
+        "narHash": "sha256-jSes9DaIVMdmwBB78KkFUVrlDzawmD62vrUg0GS2500=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "12806d31a381e7cd169a6bac35590e7b36dc5fe5",
         "type": "github"
       },
       "original": {

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -168,7 +168,7 @@ in
       if lib.versionOlder prev.php.version "7.0" then
         prev.mkExtension {
           name = "mysql";
-          internalDeps = [ prev.php.extensions.mysqlnd ];
+          internalDeps = [ final.extensions.mysqlnd ];
           configureFlags = [
             "--with-mysql"
             "--with-mysql-sock=/run/mysqld/mysqld.sock"

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -85,6 +85,19 @@ in
         ];
     });
 
+    gd =
+      if lib.versionOlder prev.php.version "7.4" then
+        prev.extensions.gd.overrideAttrs (attrs: {
+          buildInputs = attrs.buildInputs ++ [
+            # Older versions of PHP check for these libraries even when not using bundled gd.
+            pkgs.zlib
+            pkgs.libjpeg
+            pkgs.libpng
+          ];
+        })
+      else
+        prev.extensions.gd;
+
     # We now bundle the extension with PHP like PHP ≥ 7.4 does.
     hash = null;
 
@@ -358,18 +371,5 @@ in
           )
           (attrs.patches or []);
     });
-
-    gd =
-      if lib.versionOlder prev.php.version "7.4" then
-        prev.extensions.gd.overrideAttrs (attrs: {
-          buildInputs = attrs.buildInputs ++ [
-            # Older versions of PHP check for these libraries even when not using bundled gd.
-            pkgs.zlib
-            pkgs.libjpeg
-            pkgs.libpng
-          ];
-        })
-      else
-        prev.extensions.gd;
   };
 }

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -69,6 +69,13 @@ in
         in
         ourPatches ++ upstreamPatches;
 
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+
       postPatch =
         lib.concatStringsSep "\n" [
           (attrs.postPatch or "")
@@ -85,21 +92,54 @@ in
         ];
     });
 
+    ffi =
+      if lib.versionAtLeast prev.php.version "7.4" then
+        prev.extensions.ffi
+      else
+        null;
+
     gd =
       if lib.versionOlder prev.php.version "7.4" then
-        prev.extensions.gd.overrideAttrs (attrs: {
-          buildInputs = attrs.buildInputs ++ [
+        prev.mkExtension {
+          name = "gd";
+
+          buildInputs = [
+            pkgs.gd
+            pkgs.xorg.libXpm
             # Older versions of PHP check for these libraries even when not using bundled gd.
             pkgs.zlib
             pkgs.libjpeg
             pkgs.libpng
           ];
-        })
+
+          configureFlags = [
+            "--with-gd=${pkgs.gd.dev}"
+            "--with-freetype-dir=${pkgs.freetype.dev}"
+            "--with-jpeg-dir=${pkgs.libjpeg.dev}"
+            "--with-png-dir=${pkgs.libpng.dev}"
+            "--with-webp-dir=${pkgs.libwebp}"
+            "--with-xpm-dir=${pkgs.xorg.libXpm.dev}"
+            "--with-zlib-dir=${pkgs.zlib.dev}"
+            "--enable-gd-jis-conv"
+          ];
+
+          doCheck = false;
+        }
       else
         prev.extensions.gd;
 
-    # We now bundle the extension with PHP like PHP ≥ 7.4 does.
-    hash = null;
+    gettext = prev.extensions.gettext.overrideAttrs (attrs: {
+      patches =
+        attrs.patches or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Fix darwin build
+          # Introduced in https://github.com/NixOS/nixpkgs/commit/af064a0e12ad8e5a8a2e8d8ad25fc0baf3f8ef54
+          (pkgs.fetchpatch {
+            url = "https://github.com/php/php-src/commit/632b6e7aac207194adc3d0b41615bfb610757f41.patch";
+            sha256 = "0xn3ivhc4p070vbk5yx0mzj2n7p04drz3f98i77amr51w0vzv046";
+          })
+        ];
+    });
 
     intl = prev.extensions.intl.overrideAttrs (attrs: {
       doCheck = if lib.versionOlder prev.php.version "7.2" then false else attrs.doCheck or true;
@@ -118,6 +158,14 @@ in
                   # Resolve conflicts of the upstream patch with the old PHP source tree.
                   patch "$out" < ${if lib.versionOlder prev.php.version "7.0" then ./patches/intl-icu-patch-5.6-compat.patch else ./patches/intl-icu-patch-7.0-compat.patch}
                 '';
+              })
+            ]
+            ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+              # Fix aarch64 build
+              # Introduced in https://github.com/NixOS/nixpkgs/commit/30e812c6c09e1b971dc902399f3dc39d542d89d9
+              (pkgs.fetchpatch {
+                url = "https://github.com/php/php-src/commit/93a9b56c90c334896e977721bfb3f38b1721cec6.patch";
+                sha256 = "055l40lpyhb0rbjn6y23qkzdhvpp7inbnn6x13cpn4inmhjqfpg4";
               })
             ];
         in
@@ -190,16 +238,29 @@ in
       else
         prev.extensions.mysqli;
 
-    mysqlnd =
-      if lib.versionOlder prev.php.version "7.1" then
-        prev.extensions.mysqlnd.overrideAttrs (attrs: {
-          postPatch = attrs.postPatch or "" + "\n" + ''
-            # Fix mysqlnd not being able to find headers.
-            ln -s $PWD/ext/ ext/mysqlnd
-          '';
-        })
-      else
-        prev.extensions.mysqlnd;
+    mysqlnd = prev.extensions.mysqlnd.overrideAttrs (attrs: {
+      patches =
+        attrs.patches or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Introduced in https://github.com/NixOS/nixpkgs/commit/2e0d4a8b39a03a0db0c6c3622473d333a44d1ec1
+          ./patches/mysqlnd_fix_compression.patch
+        ];
+
+      postPatch =
+        attrs.postPatch or ""
+        + lib.optionalString (lib.versionOlder prev.php.version "7.1") ''
+          # Fix mysqlnd not being able to find headers.
+          ln -s $PWD/ext/ ext/mysqlnd
+        '';
+
+      preConfigure =
+        attrs.preConfigure or ""
+        + lib.optionalString (lib.versionOlder prev.php.version "7.4") ''
+          substituteInPlace configure \
+            --replace '$OPENSSL_LIBDIR' '${pkgs.openssl}/lib' \
+            --replace '$OPENSSL_INCDIR' '${pkgs.openssl.dev}/include'
+        '';
+    });
 
     oci8 =
       if lib.versionOlder prev.php.version "7.0" then
@@ -212,12 +273,13 @@ in
 
     opcache = prev.extensions.opcache.overrideAttrs (attrs: {
       patches =
-        builtins.filter
-          (patch:
-            # The patch do not apply to PHP 5’s opcache.
-            patchName patch == "zend_file_cache_config.patch" -> lib.versionAtLeast prev.php.version "7.0"
-          )
-          (attrs.patches or []);
+        attrs.patches or []
+        ++ lib.optionals (lib.versionAtLeast prev.php.version "7.0" && lib.versionOlder prev.php.version "7.4") [
+          # Introduced in https://github.com/NixOS/nixpkgs/commit/2e0d4a8b39a03a0db0c6c3622473d333a44d1ec1
+          ./patches/zend_file_cache_config.patch
+        ];
+
+      doCheck = lib.versionAtLeast prev.php.version "7.4";
     });
 
     openssl = prev.extensions.openssl.overrideAttrs (attrs: {
@@ -311,6 +373,24 @@ in
       else
         throw "php.extensions.redis3 requires PHP version < 8.0.";
 
+    simplexml = prev.extensions.simplexml.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+      });
+
+    soap = prev.extensions.soap.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+      });
+
     tidy = prev.extensions.tidy.overrideAttrs (attrs: {
       patches =
         let
@@ -329,6 +409,27 @@ in
         in
         ourPatches ++ upstreamPatches;
     });
+
+    wddx =
+      if lib.versionOlder prev.php.version "7.4" then
+        prev.mkExtension {
+          name = "wddx";
+
+          buildInputs = [
+            pkgs.libxml2
+          ];
+
+          internalDeps = [
+            final.extensions.session
+          ];
+
+          configureFlags = [
+            "--enable-wddx"
+            "--with-libxml-dir=${pkgs.libxml2.dev}"
+          ];
+        }
+      else
+        null;
 
     xdebug =
       # xdebug versions were determined using https://xdebug.org/docs/compat
@@ -362,14 +463,68 @@ in
           };
         });
 
+    xml = prev.extensions.xml.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+    });
+
+    xmlreader = prev.extensions.xmlreader.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+    });
+
+    xmlrpc = prev.extensions.xmlrpc.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+    });
+
+    xmlwriter = prev.extensions.xmlwriter.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          # Required to build on darwin.
+          "--with-libxml-dir=${pkgs.libxml2.dev}"
+        ];
+    });
+
+    zip = prev.extensions.zip.overrideAttrs (attrs: {
+      configureFlags =
+        attrs.configureFlags or []
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.3") [
+          "--with-libzip"
+        ]
+        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+          "--with-zlib-dir=${pkgs.zlib.dev}"
+        ];
+    });
+
     zlib = prev.extensions.zlib.overrideAttrs (attrs: {
       patches =
-        builtins.filter
-          (patch:
-            # The patch does not apply to PHP 7’s zlib.
-            patchName patch == "zlib-darwin-tests.patch" -> lib.versionAtLeast prev.php.version "7.1"
-          )
-          (attrs.patches or []);
+        attrs.patches or []
+        ++ lib.optionals (lib.versionAtLeast prev.php.version "7.1" && lib.versionOlder prev.php.version "7.4") [
+          # Fix Darwin build
+          # Introduced in https://github.com/NixOS/nixpkgs/commit/af064a0e12ad8e5a8a2e8d8ad25fc0baf3f8ef54
+          # Derived from https://github.com/php/php-src/commit/f16b012116d6c015632741a3caada5b30ef8a699
+          ./patches/zlib-darwin-tests.patch
+        ];
+
+        configureFlags =
+          attrs.configureFlags or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            "--with-zlib-dir=${pkgs.zlib.dev}"
+          ];
     });
   };
 }

--- a/pkgs/patches/mysqlnd_fix_compression.patch
+++ b/pkgs/patches/mysqlnd_fix_compression.patch
@@ -1,0 +1,10 @@
+--- a/ext/mysqlnd/mysqlnd.h
++++ b/ext/mysqlnd/mysqlnd.h
+@@ -48,7 +48,7 @@
+ #define MYSQLND_DBG_ENABLED 0
+ #endif
+
+-#if defined(MYSQLND_COMPRESSION_WANTED) && defined(HAVE_ZLIB)
++#if defined(MYSQLND_COMPRESSION_WANTED)
+ #define MYSQLND_COMPRESSION_ENABLED 1
+ #endif

--- a/pkgs/patches/zend_file_cache_config.patch
+++ b/pkgs/patches/zend_file_cache_config.patch
@@ -1,0 +1,13 @@
+--- a/ext/opcache/zend_file_cache.c
++++ b/ext/opcache/zend_file_cache.c
+@@ -27,9 +27,9 @@
+ #include "ext/standard/md5.h"
+ #endif
+
++#include "ZendAccelerator.h"
+ #ifdef HAVE_OPCACHE_FILE_CACHE
+
+-#include "ZendAccelerator.h"
+ #include "zend_file_cache.h"
+ #include "zend_shared_alloc.h"
+ #include "zend_accelerator_util_funcs.h"

--- a/pkgs/patches/zlib-darwin-tests.patch
+++ b/pkgs/patches/zlib-darwin-tests.patch
@@ -1,0 +1,44 @@
+diff --git a/ext/zlib/tests/bug55544.phpt b/ext/zlib/tests/bug55544.phpt
+index a0d22f4fcebf4846da6781f424f87821626de5ea..e650fe6909f555d04834f4c08f7fd0d354b783e2 100644
+--- a/ext/zlib/tests/bug55544.phpt
++++ b/ext/zlib/tests/bug55544.phpt
+@@ -6,6 +6,9 @@ extension_loaded("zlib") or die("skip");
+ if (substr(PHP_OS, 0, 3) == 'WIN') {
+        die("skip not for windows");
+ }
++if (PHP_OS == "Darwin") {
++       die("skip not for darwin");
++}
+ ?>
+ --INI--
+ output_handler=ob_gzhandler
+diff --git a/ext/zlib/tests/gzencode_variation1.phpt b/ext/zlib/tests/gzencode_variation1.phpt
+index c966b2cbc5b7..2f953168fa22 100644
+--- a/ext/zlib/tests/gzencode_variation1.phpt
++++ b/ext/zlib/tests/gzencode_variation1.phpt
+@@ -10,6 +10,10 @@ if( substr(PHP_OS, 0, 3) == "WIN" ) {
+ if (!extension_loaded("zlib")) {
+ 	print "skip - ZLIB extension not loaded";
+ }
++
++if (PHP_OS == "Darwin") {
++    print "skip - OS is encoded in headers, tested header is non Darwin";
++}
+ ?>
+ --FILE--
+ <?php
+diff --git a/ext/zlib/tests/gzencode_variation2.phpt b/ext/zlib/tests/gzencode_variation2.phpt
+index 94ac42a5f1cd..9160cf519751 100644
+--- a/ext/zlib/tests/gzencode_variation2.phpt
++++ b/ext/zlib/tests/gzencode_variation2.phpt
+@@ -10,6 +10,10 @@ if( substr(PHP_OS, 0, 3) == "WIN" ) {
+ if (!extension_loaded("zlib")) {
+ 	print "skip - ZLIB extension not loaded";
+ }
++
++if (PHP_OS == "Darwin") {
++    print "skip - OS is encoded in headers, tested header is non Darwin";
++}
+ ?>
+ --FILE--
+ <?php


### PR DESCRIPTION
Still need to copy the generic.nix fixes from https://github.com/NixOS/nixpkgs/pull/172256, and double check that we are copying stuff correctly.