### PR TITLE
fix: Throw error message instead of building an invalid extension structure

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -212,7 +212,8 @@ in
           name = "json";
         }
       else
-        null;
+        # See https://php.watch/versions/8.0/ext-json
+        throw "The JSON extension is now enabled by default in PHP >= 8.";
 
     memcached =
       if lib.versionOlder prev.php.version "7.0" then


### PR DESCRIPTION
When using `loophp/nix-shell`, there is a very handy feature that let users infer PHP extensions to build by reading the `composer.json` file.

Now that most of the development switched to PHP >= 8, I got this issue:

```
$ nix build .#php81-nts --impure                                                                                                                                                       
error: value is null while a set was expected

       at /nix/store/ab40lgr2lfs53qf2k64xqwhmjbfj41wf-source/pkgs/development/interpreters/php/generic.nix:94:76:

           93|
           94|           getExtName = ext: lib.removePrefix "php-" (builtins.parseDrvName ext.name).name;
             |                                                                            ^
           95|
(use '--show-trace' to show detailed location information)
```

The `composer.json` file in use is:

```json
{
  "require": {
    "php": ">= 8",
    "ext-json": "*"
  }
}
```

And it make sense. In `fossar/nix-phps`, we are restoring the `json` extension only for PHP < 8 and in the other case, we set it to `null`. Setting it to `null` is not the best option because in `generic.nix:94` we expect an extension to have a particular structure (with a `name`, etc etc).

Therefore, in this PR I propose to throw an error when trying to use the `json` extension in PHP >= 8.