### PR TITLE
php74: 7.4.30 -> 7.4.33

### DIFF
--- a/pkgs/php/7.4.nix
+++ b/pkgs/php/7.4.nix
@@ -2,8 +2,8 @@
 
 let
   base = mkPhp {
-    version = "7.4.30";
-    hash = "sha256-tgG7EuU3IEabYOqBZ3bKwcBpawmIihGtI3my7ug1OG4=";
+    version = "7.4.33";
+    hash = "sha256-ToEXRY/lpHW/IDEocmtxvLumHEKtRj3/re5WZ6GYqYo=";
   };
 in
 base.withExtensions (


### PR DESCRIPTION
News: https://www.php.net/archive/2022.php#2022-11-03-1

```
The PHP development team announces the immediate availability of PHP 7.4.33.

This is security release that fixes an OOB read due to insufficient input validation in imageloadfont(), and a buffer overflow in hash_update() on long parameter.

All PHP 7.4 users are encouraged to upgrade to this version.
```