### PR TITLE
php.extensions.xdebug: add support for php82

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,6 @@ jobs:
         run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-mysql
 
       - name: Build Xdebug extension
-        if: ${{ steps.params.outputs.major < 8 && steps.params.outputs.minor < 2 }}
         run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-xdebug
 
       - name: Build Tidy extension

--- a/checks.nix
+++ b/checks.nix
@@ -37,7 +37,6 @@ let
 
     xdebug = {
       description = "Build Xdebug extension";
-      enabled = { php, lib, ... }: lib.versionOlder php.version "8.2";
       drv = { php, ... }: php.extensions.xdebug;
     };
 

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -475,7 +475,16 @@ in
 
     xdebug =
       # xdebug versions were determined using https://xdebug.org/docs/compat
-      if lib.versionAtLeast prev.php.version "7.2" then
+      if lib.versionAtLeast prev.php.version "8.2" then
+        prev.extensions.xdebug.overrideAttrs (attrs: {
+          name = "xdebug-3.2.0RC2";
+          version = "3.2.0RC2";
+          src = pkgs.fetchurl {
+            url = "http://pecl.php.net/get/xdebug-3.2.0RC2.tgz";
+            sha256 = "dQgXDP3Ifg+D0niWxaJ4ec71Vfr8KH40jv6QbxSyY+4=";
+          };
+        })
+      else if lib.versionAtLeast prev.php.version "7.2" then
         prev.extensions.xdebug
       else if lib.versionAtLeast prev.php.version "7.1" then
         prev.extensions.xdebug.overrideAttrs (attrs: {


### PR DESCRIPTION
Add support for XDebug 3.2.0, which is supporting PHP 8.2.

This should fix #172
