### PR TITLE
add default nix formatter and its corresponding Github action

### DIFF
--- a/.github/workflows/nix-fmt-checks.yaml
+++ b/.github/workflows/nix-fmt-checks.yaml
@@ -1,0 +1,17 @@
+name: Nix formatter checks
+
+on:
+  pull_request:
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+
+      - name: Run nix formatter tool
+        run: nix fmt . -- --check

--- a/checks.nix
+++ b/checks.nix
@@ -2,158 +2,172 @@
   system,
   packages,
   pkgs,
-}:
-
-let
+}: let
   phpPackages = builtins.filter (name: builtins.match "php[0-9]+" name != null) (builtins.attrNames packages);
 
   checks = {
     php = {
       description = "Build PHP";
-      drv = { php, ... }: php;
+      drv = {php, ...}: php;
     };
 
     imagick = {
       description = "Build Imagick extension";
-      drv = { php, ... }: php.extensions.imagick;
+      drv = {php, ...}: php.extensions.imagick;
     };
 
     redis = {
       description = "Build Redis extension";
-      drv = { php, ... }: php.extensions.redis;
+      drv = {php, ...}: php.extensions.redis;
     };
 
     redis3 = {
       description = "Build Redis 3 extension";
-      enabled = { php, lib, ... }: lib.versionOlder php.version "8";
-      drv = { php, ... }: php.extensions.redis3;
+      enabled = {
+        php,
+        lib,
+        ...
+      }:
+        lib.versionOlder php.version "8";
+      drv = {php, ...}: php.extensions.redis3;
     };
 
     mysql = {
       description = "Build MySQL extension";
-      enabled = { php, lib, ... }: lib.versionOlder php.version "7";
-      drv = { php, ... }: php.extensions.mysql;
+      enabled = {
+        php,
+        lib,
+        ...
+      }:
+        lib.versionOlder php.version "7";
+      drv = {php, ...}: php.extensions.mysql;
     };
 
     xdebug = {
       description = "Build Xdebug extension";
-      drv = { php, ... }: php.extensions.xdebug;
+      drv = {php, ...}: php.extensions.xdebug;
     };
 
     tidy = {
       description = "Build Tidy extension";
-      drv = { php, ... }: php.extensions.tidy;
+      drv = {php, ...}: php.extensions.tidy;
     };
 
     composer-phar = {
       description = "Check that composer PHAR works";
-      drv =
-        { pkgs, php, ... }:
+      drv = {
+        pkgs,
+        php,
+        ...
+      }:
         pkgs.runCommand
-          "composer-phar-check"
-          {
-            buildInputs = [
-              php.packages.composer
-            ];
-          }
-          ''
-            composer --version
-            touch "$out"
-          '';
+        "composer-phar-check"
+        {
+          buildInputs = [
+            php.packages.composer
+          ];
+        }
+        ''
+          composer --version
+          touch "$out"
+        '';
     };
 
     mysqli-socket-path = {
       description = "Validate php.extensions.mysqli default unix socket path";
-      drv =
-        { pkgs, php, ... }:
+      drv = {
+        pkgs,
+        php,
+        ...
+      }:
         pkgs.runCommand
-          "mysqli-socket-path-check"
-          {
-            buildInputs = [
-              (php.withExtensions ({ all, ... }: [
-                all.mysqli
-              ]))
-            ];
-          }
-          ''
-            php -r "echo ini_get('mysqli.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
-            touch "$out"
-          '';
+        "mysqli-socket-path-check"
+        {
+          buildInputs = [
+            (php.withExtensions ({all, ...}: [
+              all.mysqli
+            ]))
+          ];
+        }
+        ''
+          php -r "echo ini_get('mysqli.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
+          touch "$out"
+        '';
     };
 
     pdo_mysql-socket-path = {
       description = "Validate php.extensions.pdo_mysql default unix socket path";
-      drv =
-        { pkgs, php, ... }:
+      drv = {
+        pkgs,
+        php,
+        ...
+      }:
         pkgs.runCommand
-          "pdo_mysql-socket-path-check"
-          {
-            buildInputs = [
-              (php.withExtensions ({ all, ... }: [
-                all.pdo_mysql
-              ]))
-            ];
-          }
-          ''
-            php -r "echo ini_get('pdo_mysql.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
-            touch "$out"
-          '';
+        "pdo_mysql-socket-path-check"
+        {
+          buildInputs = [
+            (php.withExtensions ({all, ...}: [
+              all.pdo_mysql
+            ]))
+          ];
+        }
+        ''
+          php -r "echo ini_get('pdo_mysql.default_socket') . PHP_EOL;" | grep /run/mysqld/mysqld.sock
+          touch "$out"
+        '';
     };
   };
 
   inherit (pkgs) lib;
 
-  /* AttrSet<phpName, AttrSet<checkName, checkDrv>> */
-  checksPerVersion =
-    lib.listToAttrs (
-      builtins.map
-        (phpName:
-          let
-            php = packages.${phpName};
-            phpVersion = lib.versions.majorMinor php.version;
-            args = { inherit lib php pkgs system; };
-            supportedChecks = lib.filterAttrs (_name: { enabled ? lib.const true, ... }: enabled args) checks;
-          in
-          {
-            name = phpName;
-            value =
-              lib.mapAttrs
-                (
-                  _name:
-                  {
-                    description,
-                    drv,
-                    ...
-                  }:
-
-                  let
-                    check = drv args;
-                  in
-                  check // {
-                    passthru = check.passthru or { } // {
-                      description = "PHP ${phpVersion} – ${description}";
-                    };
-                  }
-                )
-                supportedChecks;
-          }
-        )
-        phpPackages
-    );
+  # AttrSet<phpName, AttrSet<checkName, checkDrv>>
+  checksPerVersion = lib.listToAttrs (
+    builtins.map
+    (
+      phpName: let
+        php = packages.${phpName};
+        phpVersion = lib.versions.majorMinor php.version;
+        args = {inherit lib php pkgs system;};
+        supportedChecks = lib.filterAttrs (_name: {enabled ? lib.const true, ...}: enabled args) checks;
+      in {
+        name = phpName;
+        value =
+          lib.mapAttrs
+          (
+            _name: {
+              description,
+              drv,
+              ...
+            }: let
+              check = drv args;
+            in
+              check
+              // {
+                passthru =
+                  check.passthru
+                  or {}
+                  // {
+                    description = "PHP ${phpVersion} – ${description}";
+                  };
+              }
+          )
+          supportedChecks;
+      }
+    )
+    phpPackages
+  );
 in
-lib.foldAttrs
+  lib.foldAttrs
   lib.mergeAttrs
   {}
   (
     lib.mapAttrsToList
     (
       phpName:
-
-      lib.mapAttrs'
+        lib.mapAttrs'
         (
           name:
-
-          lib.nameValuePair "${phpName}-${name}"
+            lib.nameValuePair "${phpName}-${name}"
         )
     )
     checksPerVersion

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,12 @@
 (import (
-  let
-    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  in fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-    sha256 = lock.nodes.flake-compat.locked.narHash; }
-) {
-  src =  ./.;
-}).defaultNix
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  ) {
+    src = ./.;
+  })
+.defaultNix

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
           ];
         };
       in rec {
+        formatter = pkgs.alejandra;
+
         packages = {
           inherit (pkgs) php php56 php70 php71 php72 php73 php74 php80 php81 php82;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,15 @@
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, flake-compat, nixpkgs, utils }:
-    # For each supported platform,
-    utils.lib.eachDefaultSystem (system:
-      let
+  outputs = {
+    self,
+    flake-compat,
+    nixpkgs,
+    utils,
+  }:
+  # For each supported platform,
+    utils.lib.eachDefaultSystem (
+      system: let
         # Let’s merge the package set from Nixpkgs with our custom PHP versions.
         pkgs = import nixpkgs.outPath {
           config = {
@@ -38,7 +43,8 @@
           inherit packages pkgs system;
         };
       }
-    ) // {
+    )
+    // {
       overlays.default = import ./pkgs/phps.nix nixpkgs.outPath;
     };
 }

--- a/pkgs/composer/1.x.nix
+++ b/pkgs/composer/1.x.nix
@@ -1,35 +1,41 @@
-{ mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
-let
+{
+  mkDerivation,
+  fetchurl,
+  makeWrapper,
+  unzip,
+  lib,
+  php,
+}: let
   pname = "composer";
   version = "1.10.26";
 in
-mkDerivation {
-  inherit pname version;
+  mkDerivation {
+    inherit pname version;
 
-  src = fetchurl {
-    url = "https://getcomposer.org/download/${version}/composer.phar";
-    sha256 = "sha256-y/4fhSdsV6vkZNk0UD2TWqITSUrChidcjfq/qR49vcQ=";
-  };
+    src = fetchurl {
+      url = "https://getcomposer.org/download/${version}/composer.phar";
+      sha256 = "sha256-y/4fhSdsV6vkZNk0UD2TWqITSUrChidcjfq/qR49vcQ=";
+    };
 
-  dontUnpack = true;
+    dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [makeWrapper];
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    install -D $src $out/libexec/composer/composer.phar
-    makeWrapper ${php}/bin/php $out/bin/composer \
-      --add-flags "$out/libexec/composer/composer.phar" \
-      --prefix PATH : ${lib.makeBinPath [ unzip ]}
-    runHook postInstall
-  '';
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      install -D $src $out/libexec/composer/composer.phar
+      makeWrapper ${php}/bin/php $out/bin/composer \
+        --add-flags "$out/libexec/composer/composer.phar" \
+        --prefix PATH : ${lib.makeBinPath [unzip]}
+      runHook postInstall
+    '';
 
-  meta = with lib; {
-    description = "Dependency Manager for PHP";
-    license = licenses.mit;
-    homepage = "https://getcomposer.org/";
-    changelog = "https://github.com/composer/composer/releases/tag/${version}";
-    maintainers = with maintainers; [ offline ] ++ teams.php.members;
-  };
-}
+    meta = with lib; {
+      description = "Dependency Manager for PHP";
+      license = licenses.mit;
+      homepage = "https://getcomposer.org/";
+      changelog = "https://github.com/composer/composer/releases/tag/${version}";
+      maintainers = with maintainers; [offline] ++ teams.php.members;
+    };
+  }

--- a/pkgs/composer/2.2.nix
+++ b/pkgs/composer/2.2.nix
@@ -1,35 +1,41 @@
-{ mkDerivation, fetchurl, makeWrapper, unzip, lib, php }:
-let
+{
+  mkDerivation,
+  fetchurl,
+  makeWrapper,
+  unzip,
+  lib,
+  php,
+}: let
   pname = "composer";
   version = "2.2.12";
 in
-mkDerivation {
-  inherit pname version;
+  mkDerivation {
+    inherit pname version;
 
-  src = fetchurl {
-    url = "https://getcomposer.org/download/${version}/composer.phar";
-    sha256 = "sha256-HOkGh+s/iamcBZ1F3UGdCEMO0klGhUS5MrHa1/si3aA=";
-  };
+    src = fetchurl {
+      url = "https://getcomposer.org/download/${version}/composer.phar";
+      sha256 = "sha256-HOkGh+s/iamcBZ1F3UGdCEMO0klGhUS5MrHa1/si3aA=";
+    };
 
-  dontUnpack = true;
+    dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [makeWrapper];
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    install -D $src $out/libexec/composer/composer.phar
-    makeWrapper ${php}/bin/php $out/bin/composer \
-      --add-flags "$out/libexec/composer/composer.phar" \
-      --prefix PATH : ${lib.makeBinPath [ unzip ]}
-    runHook postInstall
-  '';
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      install -D $src $out/libexec/composer/composer.phar
+      makeWrapper ${php}/bin/php $out/bin/composer \
+        --add-flags "$out/libexec/composer/composer.phar" \
+        --prefix PATH : ${lib.makeBinPath [unzip]}
+      runHook postInstall
+    '';
 
-  meta = with lib; {
-    description = "Dependency Manager for PHP";
-    license = licenses.mit;
-    homepage = "https://getcomposer.org/";
-    changelog = "https://github.com/composer/composer/releases/tag/${version}";
-    maintainers = with maintainers; [ offline ] ++ teams.php.members;
-  };
-}
+    meta = with lib; {
+      description = "Dependency Manager for PHP";
+      license = licenses.mit;
+      homepage = "https://getcomposer.org/";
+      changelog = "https://github.com/composer/composer/releases/tag/${version}";
+      maintainers = with maintainers; [offline] ++ teams.php.members;
+    };
+  }

--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -1,42 +1,34 @@
 # SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
 # SPDX-License-Identifier: MIT
+{lib}: {
+  /*
+  * Remove given lines from a string.
 
-{
-  lib,
-}:
+  Will fail loudly if any of the lines is not present.
 
-{
-  /** Remove given lines from a string.
+  Type: removeLines :: [string] -> string -> string
 
-    Will fail loudly if any of the lines is not present.
-
-    Type: removeLines :: [string] -> string -> string
-
-    Complexity: O(|lines| × |string|)
+  Complexity: O(|lines| × |string|)
   */
-  removeLines =
-    lines:
-    string:
-
-    let
-      lineRegexp = line: "(.*)(^|\n)" + lib.escapeRegex line + "($|\n)(.*)";
-      isLinePresent = line: haystack: builtins.match (lineRegexp line) haystack != null;
-      lineAssertion = line: haystack: lib.assertMsg (isLinePresent line haystack) ("Unable to remove line “" + line + "”, it is not present in “" + haystack + "”.");
-      removeLine =
-        string:
-        line:
-
-        let
-          result = builtins.match (lineRegexp line) string;
-          linesBefore = builtins.elemAt result 0;
-          separatorBefore = builtins.elemAt result 1;
-          separatorAfter = builtins.elemAt result 2;
-          linesAfter = builtins.elemAt result 3;
-        in
-          linesBefore + (if separatorBefore != "" then separatorBefore else separatorAfter) + linesAfter;
+  removeLines = lines: string: let
+    lineRegexp = line: "(.*)(^|\n)" + lib.escapeRegex line + "($|\n)(.*)";
+    isLinePresent = line: haystack: builtins.match (lineRegexp line) haystack != null;
+    lineAssertion = line: haystack: lib.assertMsg (isLinePresent line haystack) ("Unable to remove line “" + line + "”, it is not present in “" + haystack + "”.");
+    removeLine = string: line: let
+      result = builtins.match (lineRegexp line) string;
+      linesBefore = builtins.elemAt result 0;
+      separatorBefore = builtins.elemAt result 1;
+      separatorAfter = builtins.elemAt result 2;
+      linesAfter = builtins.elemAt result 3;
     in
-
+      linesBefore
+      + (
+        if separatorBefore != ""
+        then separatorBefore
+        else separatorAfter
+      )
+      + linesAfter;
+  in
     assert builtins.all (line: lineAssertion line string) lines;
-
-    lib.foldl removeLine string lines;
+      lib.foldl removeLine string lines;
 }

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -1,16 +1,12 @@
 # Nixpkgs packages.
 pkgs:
-
 # Overlay to be passed as packageOverrides to Nixpkgs’s generic PHP builder:
-
-final:
-prev:
-
-let
+final: prev: let
   patchName = patch: patch.name or (builtins.baseNameOf patch);
 
   linkInternalDeps = extensions: ''
-    ${lib.concatMapStringsSep
+    ${
+      lib.concatMapStringsSep
       "\n"
       (dep: "mkdir -p ext; ln -s ${dep.dev}/include ext/${dep.extensionName}")
       extensions
@@ -19,82 +15,82 @@ let
 
   inherit (pkgs) lib;
 
-  inherit (import ./lib.nix { inherit lib; }) removeLines;
-in
+  inherit (import ./lib.nix {inherit lib;}) removeLines;
+in {
+  buildPecl = {internalDeps ? [], ...} @ args:
+    prev.buildPecl (args
+      // {
+        # We started bundling hash so we need to remove
+        # references to the external extension which no longer exists.
+        internalDeps = builtins.filter (d: d != null) internalDeps;
+      });
 
-{
-  buildPecl =
-    {
-      internalDeps ? [],
-      ...
-    }@args:
+  tools =
+    prev.tools
+    // {
+      php-cs-fixer-2 = final.callPackage ./php-cs-fixer/2.x.nix {};
+    }
+    // lib.optionalAttrs (lib.versionOlder prev.php.version "7.2.5") {
+      composer = final.callPackage ./composer/2.2.nix {};
+      composer-1 = final.callPackage ./composer/1.x.nix {};
+    };
 
-    prev.buildPecl (args // {
-      # We started bundling hash so we need to remove
-      # references to the external extension which no longer exists.
-      internalDeps = builtins.filter (d: d != null) internalDeps;
-    });
+  extensions =
+    prev.extensions
+    // {
+      apcu =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.extensions.apcu.overrideAttrs (attrs: {
+            name = "apcu-4.0.11";
+            version = "4.0.11";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/apcu-4.0.11.tgz";
+              sha256 = "002d1gklkf0z170wkbhmm2z1p9p5ghhq3q1r9k54fq1sq4p30ks5";
+            };
+          })
+        else prev.extensions.apcu;
 
-  tools = prev.tools // {
-    php-cs-fixer-2 = final.callPackage ./php-cs-fixer/2.x.nix { };
-    composer-1 = final.callPackage ./composer/1.x.nix { };
-  } // lib.optionalAttrs (lib.versionOlder prev.php.version "7.2.5") {
-    composer = final.callPackage ./composer/2.2.nix { };
-  };
+      couchbase = prev.extensions.couchbase.overrideAttrs (attrs: {
+        preConfigure =
+          attrs.preConfigure or "" + linkInternalDeps [final.extensions.json];
+      });
 
-  extensions = prev.extensions // {
-    apcu =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.apcu.overrideAttrs (attrs: {
-          name = "apcu-4.0.11";
-          version = "4.0.11";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/apcu-4.0.11.tgz";
-            sha256 = "002d1gklkf0z170wkbhmm2z1p9p5ghhq3q1r9k54fq1sq4p30ks5";
-          };
-        })
-      else
-        prev.extensions.apcu;
-
-    couchbase = prev.extensions.couchbase.overrideAttrs (attrs: {
-      preConfigure =
-        attrs.preConfigure or "" + linkInternalDeps [ final.extensions.json ];
-    });
-
-    dom = prev.extensions.dom.overrideAttrs (attrs: {
-      patches =
-        let
+      dom = prev.extensions.dom.overrideAttrs (attrs: {
+        patches = let
           upstreamPatches =
             attrs.patches or [];
 
-          ourPatches = lib.optionals (lib.versionOlder prev.php.version "7.2") [
-            # Fix tests with libxml2 2.9.10.
-            (pkgs.fetchpatch {
-              url = "https://github.com/php/php-src/commit/e29922f054639a934f3077190729007896ae244c.patch";
-              sha256 = "zC2QE6snAhhA7ItXgrc80WlDVczTlZEzgZsD7AS+gtw=";
-            })
-          ] ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-            (pkgs.fetchpatch {
-              url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
-              sha256 = "11qsdiwj1zmpfc2pgh6nr0sn7qa1nyjg4jwf69cgwnd57qfjcy4k";
-              excludes = [
-                "ext/dom/tests/bug43364.phpt"
-                "ext/dom/tests/bug80268.phpt"
-              ];
-            })
-          ];
+          ourPatches =
+            lib.optionals (lib.versionOlder prev.php.version "7.2") [
+              # Fix tests with libxml2 2.9.10.
+              (pkgs.fetchpatch {
+                url = "https://github.com/php/php-src/commit/e29922f054639a934f3077190729007896ae244c.patch";
+                sha256 = "zC2QE6snAhhA7ItXgrc80WlDVczTlZEzgZsD7AS+gtw=";
+              })
+            ]
+            ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+              (pkgs.fetchpatch {
+                url = "https://github.com/php/php-src/commit/4cc261aa6afca2190b1b74de39c3caa462ec6f0b.patch";
+                sha256 = "11qsdiwj1zmpfc2pgh6nr0sn7qa1nyjg4jwf69cgwnd57qfjcy4k";
+                excludes = [
+                  "ext/dom/tests/bug43364.phpt"
+                  "ext/dom/tests/bug80268.phpt"
+                ];
+              })
+            ];
         in
-        ourPatches ++ upstreamPatches;
+          ourPatches ++ upstreamPatches;
 
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Required to build on darwin.
-          "--with-libxml-dir=${pkgs.libxml2.dev}"
-        ];
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Required to build on darwin.
+            "--with-libxml-dir=${pkgs.libxml2.dev}"
+          ];
 
-      postPatch =
-        lib.concatStringsSep "\n" [
+        postPatch = lib.concatStringsSep "\n" [
           (attrs.postPatch or "")
 
           (lib.optionalString (lib.versionOlder prev.php.version "7.4" && lib.versionAtLeast prev.php.version "7.3") ''
@@ -107,66 +103,68 @@ in
             rm ext/dom/tests/bug43364.phpt
           '')
         ];
-    });
+      });
 
-    ds = prev.extensions.ds.overrideAttrs (attrs: {
-      preConfigure =
-        attrs.preConfigure or "" linkInternalDeps [ final.extensions.json ];
-    });
+      ds = prev.extensions.ds.overrideAttrs (attrs: {
+        preConfigure =
+          attrs.preConfigure or "" linkInternalDeps [final.extensions.json];
+      });
 
-    ffi =
-      if lib.versionAtLeast prev.php.version "7.4" then
-        prev.extensions.ffi
-      else
-        null;
+      ffi =
+        if lib.versionAtLeast prev.php.version "7.4"
+        then prev.extensions.ffi
+        else null;
 
-    gd =
-      if lib.versionOlder prev.php.version "7.4" then
-        prev.mkExtension {
-          name = "gd";
+      gd =
+        if lib.versionOlder prev.php.version "7.4"
+        then
+          prev.mkExtension {
+            name = "gd";
 
-          buildInputs = [
-            pkgs.gd
-            pkgs.xorg.libXpm
-            # Older versions of PHP check for these libraries even when not using bundled gd.
-            pkgs.zlib
-            pkgs.libjpeg
-            pkgs.libpng
+            buildInputs = [
+              pkgs.gd
+              pkgs.xorg.libXpm
+              # Older versions of PHP check for these libraries even when not using bundled gd.
+              pkgs.zlib
+              pkgs.libjpeg
+              pkgs.libpng
+            ];
+
+            configureFlags = [
+              "--with-gd=${pkgs.gd.dev}"
+              "--with-freetype-dir=${pkgs.freetype.dev}"
+              "--with-jpeg-dir=${pkgs.libjpeg.dev}"
+              "--with-png-dir=${pkgs.libpng.dev}"
+              "--with-webp-dir=${pkgs.libwebp}"
+              "--with-xpm-dir=${pkgs.xorg.libXpm.dev}"
+              "--with-zlib-dir=${pkgs.zlib.dev}"
+              "--enable-gd-jis-conv"
+            ];
+
+            doCheck = false;
+          }
+        else prev.extensions.gd;
+
+      gettext = prev.extensions.gettext.overrideAttrs (attrs: {
+        patches =
+          attrs.patches
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Fix darwin build
+            # Introduced in https://github.com/NixOS/nixpkgs/commit/af064a0e12ad8e5a8a2e8d8ad25fc0baf3f8ef54
+            (pkgs.fetchpatch {
+              url = "https://github.com/php/php-src/commit/632b6e7aac207194adc3d0b41615bfb610757f41.patch";
+              sha256 = "0xn3ivhc4p070vbk5yx0mzj2n7p04drz3f98i77amr51w0vzv046";
+            })
           ];
+      });
 
-          configureFlags = [
-            "--with-gd=${pkgs.gd.dev}"
-            "--with-freetype-dir=${pkgs.freetype.dev}"
-            "--with-jpeg-dir=${pkgs.libjpeg.dev}"
-            "--with-png-dir=${pkgs.libpng.dev}"
-            "--with-webp-dir=${pkgs.libwebp}"
-            "--with-xpm-dir=${pkgs.xorg.libXpm.dev}"
-            "--with-zlib-dir=${pkgs.zlib.dev}"
-            "--enable-gd-jis-conv"
-          ];
-
-          doCheck = false;
-        }
-      else
-        prev.extensions.gd;
-
-    gettext = prev.extensions.gettext.overrideAttrs (attrs: {
-      patches =
-        attrs.patches or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Fix darwin build
-          # Introduced in https://github.com/NixOS/nixpkgs/commit/af064a0e12ad8e5a8a2e8d8ad25fc0baf3f8ef54
-          (pkgs.fetchpatch {
-            url = "https://github.com/php/php-src/commit/632b6e7aac207194adc3d0b41615bfb610757f41.patch";
-            sha256 = "0xn3ivhc4p070vbk5yx0mzj2n7p04drz3f98i77amr51w0vzv046";
-          })
-        ];
-    });
-
-    intl = prev.extensions.intl.overrideAttrs (attrs: {
-      doCheck = if lib.versionOlder prev.php.version "7.2" then false else attrs.doCheck or true;
-      patches =
-        let
+      intl = prev.extensions.intl.overrideAttrs (attrs: {
+        doCheck =
+          if lib.versionOlder prev.php.version "7.2"
+          then false
+          else attrs.doCheck or true;
+        patches = let
           upstreamPatches =
             attrs.patches or [];
 
@@ -175,10 +173,17 @@ in
               # Fix build with newer ICU.
               (pkgs.fetchpatch {
                 url = "https://github.com/php/php-src/commit/8d35a423838eb462cd39ee535c5d003073cc5f22.patch";
-                sha256 = if lib.versionOlder prev.php.version "7.0" then "8v0k6zaE5w4yCopCVa470TMozAXyK4fQelr+KuVnAv4=" else "NO3EY5z1LFWKor9c/9rJo1rpigG5x8W3Uj5+xAOwm+g=";
+                sha256 =
+                  if lib.versionOlder prev.php.version "7.0"
+                  then "8v0k6zaE5w4yCopCVa470TMozAXyK4fQelr+KuVnAv4="
+                  else "NO3EY5z1LFWKor9c/9rJo1rpigG5x8W3Uj5+xAOwm+g=";
                 postFetch = ''
                   # Resolve conflicts of the upstream patch with the old PHP source tree.
-                  patch "$out" < ${if lib.versionOlder prev.php.version "7.0" then ./patches/intl-icu-patch-5.6-compat.patch else ./patches/intl-icu-patch-7.0-compat.patch}
+                  patch "$out" < ${
+                    if lib.versionOlder prev.php.version "7.0"
+                    then ./patches/intl-icu-patch-5.6-compat.patch
+                    else ./patches/intl-icu-patch-7.0-compat.patch
+                  }
                 '';
               })
             ]
@@ -191,322 +196,323 @@ in
               })
             ];
         in
-        ourPatches ++ upstreamPatches;
-    });
+          ourPatches ++ upstreamPatches;
+      });
 
-    iconv = prev.extensions.iconv.overrideAttrs (attrs: {
-      patches =
-        let
+      iconv = prev.extensions.iconv.overrideAttrs (attrs: {
+        patches = let
           upstreamPatches =
             attrs.patches or [];
 
-          ourPatches =
-            lib.optionals (lib.versionOlder prev.php.version "8.0") [
-              # Header path defaults to FHS location, preventing the configure script from detecting errno support.
-              ./patches/iconv-header-path.patch
-            ];
+          ourPatches = lib.optionals (lib.versionOlder prev.php.version "8.0") [
+            # Header path defaults to FHS location, preventing the configure script from detecting errno support.
+            ./patches/iconv-header-path.patch
+          ];
         in
-        ourPatches ++ upstreamPatches;
-    });
+          ourPatches ++ upstreamPatches;
+      });
 
-    json =
-      if lib.versionOlder prev.php.version "8.0" then
-        prev.mkExtension {
-          name = "json";
-        }
-      else
-        null;
+      json =
+        if lib.versionOlder prev.php.version "8.0"
+        then
+          prev.mkExtension {
+            name = "json";
+          }
+        else null;
 
-    memcached =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.memcached.overrideAttrs (attrs: {
-          name = "memcached-2.2.0";
-          version = "2.2.0";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/memcached-2.2.0.tgz";
-            sha256 = "0n4z2mp4rvrbmxq079zdsrhjxjkmhz6mzi7mlcipz02cdl7n1f8p";
-          };
-        })
-      else
-        prev.extensions.memcached;
+      memcached =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.extensions.memcached.overrideAttrs (attrs: {
+            name = "memcached-2.2.0";
+            version = "2.2.0";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/memcached-2.2.0.tgz";
+              sha256 = "0n4z2mp4rvrbmxq079zdsrhjxjkmhz6mzi7mlcipz02cdl7n1f8p";
+            };
+          })
+        else prev.extensions.memcached;
 
-    mssql =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.mkExtension {
-          name = "mssql";
-          configureFlags = [
-            "--with-mssql=${pkgs.freetds}"
+      mssql =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.mkExtension {
+            name = "mssql";
+            configureFlags = [
+              "--with-mssql=${pkgs.freetds}"
+            ];
+          }
+        else null;
+
+      mysql =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.mkExtension {
+            name = "mysql";
+            internalDeps = [final.extensions.mysqlnd];
+            configureFlags = [
+              "--with-mysql"
+              "--with-mysql-sock=/run/mysqld/mysqld.sock"
+            ];
+            postPatch = ''
+              # Fix mysql not being able to find headers.
+              ln -s $PWD/ext/ ext/mysql
+            '';
+          }
+        else null;
+
+      mysqli =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.extensions.mysqli.overrideAttrs (attrs: {
+            # the --with-mysql-sock option didn't exist in php 5.6
+            NIX_CFLAGS_COMPILE = "-DPHP_MYSQL_UNIX_SOCK_ADDR=\"/run/mysqld/mysqld.sock\"";
+          })
+        else prev.extensions.mysqli;
+
+      mysqlnd = prev.extensions.mysqlnd.overrideAttrs (attrs: {
+        patches =
+          attrs.patches
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Introduced in https://github.com/NixOS/nixpkgs/commit/2e0d4a8b39a03a0db0c6c3622473d333a44d1ec1
+            ./patches/mysqlnd_fix_compression.patch
           ];
-        }
-      else
-        null;
 
-    mysql =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.mkExtension {
-          name = "mysql";
-          internalDeps = [ final.extensions.mysqlnd ];
-          configureFlags = [
-            "--with-mysql"
-            "--with-mysql-sock=/run/mysqld/mysqld.sock"
-          ];
-          postPatch = ''
-            # Fix mysql not being able to find headers.
-            ln -s $PWD/ext/ ext/mysql
+        postPatch =
+          attrs.postPatch
+          or ""
+          + lib.optionalString (lib.versionOlder prev.php.version "7.1") ''
+            # Fix mysqlnd not being able to find headers.
+            ln -s $PWD/ext/ ext/mysqlnd
           '';
-        }
-      else
-        null;
 
-    mysqli =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.mysqli.overrideAttrs (attrs: {
-          # the --with-mysql-sock option didn't exist in php 5.6
-          NIX_CFLAGS_COMPILE = "-DPHP_MYSQL_UNIX_SOCK_ADDR=\"/run/mysqld/mysqld.sock\"";
-        })
-      else
-        prev.extensions.mysqli;
+        preConfigure =
+          attrs.preConfigure
+          or ""
+          + lib.optionalString (lib.versionOlder prev.php.version "7.4") ''
+            substituteInPlace configure \
+              --replace '$OPENSSL_LIBDIR' '${pkgs.openssl}/lib' \
+              --replace '$OPENSSL_INCDIR' '${pkgs.openssl.dev}/include'
+          '';
+      });
 
-    mysqlnd = prev.extensions.mysqlnd.overrideAttrs (attrs: {
-      patches =
-        attrs.patches or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Introduced in https://github.com/NixOS/nixpkgs/commit/2e0d4a8b39a03a0db0c6c3622473d333a44d1ec1
-          ./patches/mysqlnd_fix_compression.patch
-        ];
+      oci8 =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.extensions.oci8.overrideAttrs (attrs: {
+            name = "oci8-2.0.12";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/oci8-2.0.12.tgz";
+              sha256 = "1khqa7fs8dbyjclx05a5ls1f8paw1ij21qwlx3v7p8i3iqhnymkj";
+            };
+          })
+        else if lib.versionOlder prev.php.version "8.0"
+        then
+          prev.extensions.oci8.overrideAttrs (attrs: {
+            name = "oci8-2.2.0";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/oci8-2.2.0.tgz";
+              sha256 = "0jhivxj1nkkza4h23z33y7xhffii60d7dr51h1czjk10qywl7pyd";
+            };
+          })
+        else prev.extensions.oci8;
 
-      postPatch =
-        attrs.postPatch or ""
-        + lib.optionalString (lib.versionOlder prev.php.version "7.1") ''
-          # Fix mysqlnd not being able to find headers.
-          ln -s $PWD/ext/ ext/mysqlnd
-        '';
+      opcache = prev.extensions.opcache.overrideAttrs (attrs: {
+        patches =
+          attrs.patches
+          or []
+          ++ lib.optionals (lib.versionAtLeast prev.php.version "7.0" && lib.versionOlder prev.php.version "7.4") [
+            # Introduced in https://github.com/NixOS/nixpkgs/commit/2e0d4a8b39a03a0db0c6c3622473d333a44d1ec1
+            ./patches/zend_file_cache_config.patch
+          ];
 
-      preConfigure =
-        attrs.preConfigure or ""
-        + lib.optionalString (lib.versionOlder prev.php.version "7.4") ''
-          substituteInPlace configure \
-            --replace '$OPENSSL_LIBDIR' '${pkgs.openssl}/lib' \
-            --replace '$OPENSSL_INCDIR' '${pkgs.openssl.dev}/include'
-        '';
-    });
+        doCheck = lib.versionAtLeast prev.php.version "7.4";
 
-    oci8 =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.oci8.overrideAttrs (attrs: {
-          name = "oci8-2.0.12";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/oci8-2.0.12.tgz";
-            sha256 = "1khqa7fs8dbyjclx05a5ls1f8paw1ij21qwlx3v7p8i3iqhnymkj";
-          };
-        })
-      else if lib.versionOlder prev.php.version "8.0" then
-        prev.extensions.oci8.overrideAttrs (attrs: {
-          name = "oci8-2.2.0";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/oci8-2.2.0.tgz";
-            sha256 = "0jhivxj1nkkza4h23z33y7xhffii60d7dr51h1czjk10qywl7pyd";
-          };
-        })
-      else
-        prev.extensions.oci8;
-
-    opcache = prev.extensions.opcache.overrideAttrs (attrs: {
-      patches =
-        attrs.patches or []
-        ++ lib.optionals (lib.versionAtLeast prev.php.version "7.0" && lib.versionOlder prev.php.version "7.4") [
-          # Introduced in https://github.com/NixOS/nixpkgs/commit/2e0d4a8b39a03a0db0c6c3622473d333a44d1ec1
-          ./patches/zend_file_cache_config.patch
-        ];
-
-      doCheck = lib.versionAtLeast prev.php.version "7.4";
-
-      postPatch =
-        removeLines
+        postPatch =
+          removeLines
           (lib.optionals (lib.versionOlder prev.php.version "7.2.20" && pkgs.stdenv.isDarwin) [
             "rm ext/opcache/tests/bug78106.phpt"
           ])
           attrs.postPatch;
-    });
-
-    openssl = prev.extensions.openssl.overrideAttrs (attrs: {
-      patches =
-        let
-          upstreamPatches =
-            attrs.patches or [];
-
-          ourPatches =
-            lib.optionals (lib.versionOlder prev.php.version "7.0") [
-              # PHP ≤ 5.6 requires openssl 1.0.
-              # https://github.com/php-build/php-build/pull/609
-              # https://github.com/oerdnj/deb.sury.org/issues/566
-              (pkgs.fetchurl {
-                url = "https://github.com/php-build/php-build/raw/43c8e02689bc29d48daa338b73bcd4f2bbd8def1/share/php-build/patches/php-5.6-support-openssl-1.1.0.patch";
-                sha256 = "UHu3SyYSMozfXlm5ZGRaSdD5NnrdAB7NaY4P0NREVCE=";
-              })
-            ];
-        in
-        ourPatches ++ upstreamPatches;
-    });
-
-    pdo = prev.extensions.pdo.overrideAttrs (attrs: {
-      patches =
-        let
-          upstreamPatches =
-            attrs.patches or [];
-
-          ourPatches =
-            lib.optionals (lib.versionOlder prev.php.version "7.2") [
-              # Fix Darwin builds on 7.1
-              (pkgs.fetchpatch {
-                url = "https://github.com/php/php-src/commit/11eed9f3ba7429be467b54d8407cfbd6bd7e6f3a.patch";
-                sha256 = "1mvdsc3kc1fb2l3fh6hva20gyay1214zqj24mavp7x6g0ngii06l";
-              })
-            ];
-        in
-        ourPatches ++ upstreamPatches;
-    });
-
-    pdo_mysql =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.pdo_mysql.overrideAttrs (attrs: {
-          # PHP_MYSQL_SOCK didn't exist in php 5.6
-          NIX_CFLAGS_COMPILE = "-DPDO_MYSQL_UNIX_ADDR=\"/run/mysqld/mysqld.sock\"";
-        })
-      else
-        prev.extensions.pdo_mysql;
-
-    readline = prev.extensions.readline.overrideAttrs (attrs: {
-      patches =
-        let
-          upstreamPatches =
-            attrs.patches or [];
-
-          ourPatches =
-            lib.optionals (lib.versionOlder prev.php.version "7.2") [
-              # Fix readline build
-              (pkgs.fetchpatch {
-                url = "https://github.com/php/php-src/commit/1ea58b6e78355437b79fb7b1f287ba6688fb1c57.patch";
-                sha256 = "Lh2h07lKkAXpyBGqgLDNXeiOocksARTYIysLWMon694=";
-              })
-            ];
-        in
-        ourPatches ++ upstreamPatches;
-    });
-
-    redis =
-      if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.redis.overrideAttrs (attrs: {
-          name = "redis-4.3.0";
-          version = "4.3.0";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/redis-4.3.0.tgz";
-            sha256 = "wPBM7DSZYKhCtgkg+4pDNlbi5JTq7W5mM5fWcQKlG6I=";
-          };
-        })
-      else if lib.versionOlder prev.php.version "8.0" then
-        prev.extensions.redis.overrideAttrs (attrs: {
-          preConfigure =
-            attrs.preConfigure or "" + linkInternalDeps [ final.extensions.json ];
-        })
-      else
-        prev.extensions.redis;
-
-    redis3 =
-      if lib.versionOlder prev.php.version "8.0" then
-        prev.extensions.redis.overrideAttrs (attrs: {
-          name = "redis-3.1.6";
-          version = "3.1.6";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/redis-3.1.6.tgz";
-            sha256 = "siknTNwUwi78Qf76ANtNxbsyqZfWgRJ4ZioEOnaqJgA=";
-          };
-        })
-      else
-        throw "php.extensions.redis3 requires PHP version < 8.0.";
-
-    simplexml = prev.extensions.simplexml.overrideAttrs (attrs: {
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Required to build on darwin.
-          "--with-libxml-dir=${pkgs.libxml2.dev}"
-        ];
       });
 
-    soap = prev.extensions.soap.overrideAttrs (attrs: {
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Required to build on darwin.
-          "--with-libxml-dir=${pkgs.libxml2.dev}"
-        ];
-      });
-
-    tidy = prev.extensions.tidy.overrideAttrs (attrs: {
-      patches =
-        let
+      openssl = prev.extensions.openssl.overrideAttrs (attrs: {
+        patches = let
           upstreamPatches =
             attrs.patches or [];
 
-          ourPatches =
-            lib.optionals (lib.versionOlder prev.php.version "7.1") [
-              # Add support for the new tidy-html5 library.
-              # https://github.com/php/php-src/commit/a552ac5bd589035b66c899b74511b29a3d1a4718
-              (pkgs.fetchpatch {
-                url = "https://github.com/php/php-src/commit/a552ac5bd589035b66c899b74511b29a3d1a4718.patch";
-                sha256 = "bXDgtCYwxZ9sQLNh3RR1W+g8JWn0ottRhK5LNTtDBVA=";
-              })
-            ];
+          ourPatches = lib.optionals (lib.versionOlder prev.php.version "7.0") [
+            # PHP ≤ 5.6 requires openssl 1.0.
+            # https://github.com/php-build/php-build/pull/609
+            # https://github.com/oerdnj/deb.sury.org/issues/566
+            (pkgs.fetchurl {
+              url = "https://github.com/php-build/php-build/raw/43c8e02689bc29d48daa338b73bcd4f2bbd8def1/share/php-build/patches/php-5.6-support-openssl-1.1.0.patch";
+              sha256 = "UHu3SyYSMozfXlm5ZGRaSdD5NnrdAB7NaY4P0NREVCE=";
+            })
+          ];
         in
-        ourPatches ++ upstreamPatches;
-    });
+          ourPatches ++ upstreamPatches;
+      });
 
-    wddx =
-      if lib.versionOlder prev.php.version "7.4" then
-        prev.mkExtension {
-          name = "wddx";
+      pdo = prev.extensions.pdo.overrideAttrs (attrs: {
+        patches = let
+          upstreamPatches =
+            attrs.patches or [];
 
-          buildInputs = [
-            pkgs.libxml2
+          ourPatches = lib.optionals (lib.versionOlder prev.php.version "7.2") [
+            # Fix Darwin builds on 7.1
+            (pkgs.fetchpatch {
+              url = "https://github.com/php/php-src/commit/11eed9f3ba7429be467b54d8407cfbd6bd7e6f3a.patch";
+              sha256 = "1mvdsc3kc1fb2l3fh6hva20gyay1214zqj24mavp7x6g0ngii06l";
+            })
           ];
+        in
+          ourPatches ++ upstreamPatches;
+      });
 
-          internalDeps = [
-            final.extensions.session
+      pdo_mysql =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.extensions.pdo_mysql.overrideAttrs (attrs: {
+            # PHP_MYSQL_SOCK didn't exist in php 5.6
+            NIX_CFLAGS_COMPILE = "-DPDO_MYSQL_UNIX_ADDR=\"/run/mysqld/mysqld.sock\"";
+          })
+        else prev.extensions.pdo_mysql;
+
+      readline = prev.extensions.readline.overrideAttrs (attrs: {
+        patches = let
+          upstreamPatches =
+            attrs.patches or [];
+
+          ourPatches = lib.optionals (lib.versionOlder prev.php.version "7.2") [
+            # Fix readline build
+            (pkgs.fetchpatch {
+              url = "https://github.com/php/php-src/commit/1ea58b6e78355437b79fb7b1f287ba6688fb1c57.patch";
+              sha256 = "Lh2h07lKkAXpyBGqgLDNXeiOocksARTYIysLWMon694=";
+            })
           ];
+        in
+          ourPatches ++ upstreamPatches;
+      });
 
-          configureFlags = [
-            "--enable-wddx"
+      redis =
+        if lib.versionOlder prev.php.version "7.0"
+        then
+          prev.extensions.redis.overrideAttrs (attrs: {
+            name = "redis-4.3.0";
+            version = "4.3.0";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/redis-4.3.0.tgz";
+              sha256 = "wPBM7DSZYKhCtgkg+4pDNlbi5JTq7W5mM5fWcQKlG6I=";
+            };
+          })
+        else if lib.versionOlder prev.php.version "8.0"
+        then
+          prev.extensions.redis.overrideAttrs (attrs: {
+            preConfigure =
+              attrs.preConfigure or "" + linkInternalDeps [final.extensions.json];
+          })
+        else prev.extensions.redis;
+
+      redis3 =
+        if lib.versionOlder prev.php.version "8.0"
+        then
+          prev.extensions.redis.overrideAttrs (attrs: {
+            name = "redis-3.1.6";
+            version = "3.1.6";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/redis-3.1.6.tgz";
+              sha256 = "siknTNwUwi78Qf76ANtNxbsyqZfWgRJ4ZioEOnaqJgA=";
+            };
+          })
+        else throw "php.extensions.redis3 requires PHP version < 8.0.";
+
+      simplexml = prev.extensions.simplexml.overrideAttrs (attrs: {
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Required to build on darwin.
             "--with-libxml-dir=${pkgs.libxml2.dev}"
           ];
-        }
-      else
-        null;
+      });
 
-    xdebug =
-      # xdebug versions were determined using https://xdebug.org/docs/compat
-      if lib.versionAtLeast prev.php.version "8.0" then
-        prev.extensions.xdebug
-      else if lib.versionAtLeast prev.php.version "7.2" then
-        prev.extensions.xdebug.overrideAttrs (attrs: {
-          name = "xdebug-3.1.6";
-          version = "3.1.6";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/xdebug-3.1.6.tgz";
-            sha256 = "1lnmrb5kgq8lbhjs48j3wwhqgk44pnqb1yjq4b5r6ysv9l5wlkjm";
-          };
-        })
-      else if lib.versionAtLeast prev.php.version "7.1" then
-        prev.extensions.xdebug.overrideAttrs (attrs: {
-          name = "xdebug-2.9.8";
-          version = "2.9.8";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/xdebug-2.9.8.tgz";
-            sha256 = "12igfrdfisqfmfqpc321g93pm2w1y7h24bclmxjrjv6rb36bcmgm";
-          };
-        })
-      else if lib.versionAtLeast prev.php.version "7.0" then
-        prev.extensions.xdebug.overrideAttrs (attrs: {
+      soap = prev.extensions.soap.overrideAttrs (attrs: {
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Required to build on darwin.
+            "--with-libxml-dir=${pkgs.libxml2.dev}"
+          ];
+      });
+
+      tidy = prev.extensions.tidy.overrideAttrs (attrs: {
+        patches = let
+          upstreamPatches =
+            attrs.patches or [];
+
+          ourPatches = lib.optionals (lib.versionOlder prev.php.version "7.1") [
+            # Add support for the new tidy-html5 library.
+            # https://github.com/php/php-src/commit/a552ac5bd589035b66c899b74511b29a3d1a4718
+            (pkgs.fetchpatch {
+              url = "https://github.com/php/php-src/commit/a552ac5bd589035b66c899b74511b29a3d1a4718.patch";
+              sha256 = "bXDgtCYwxZ9sQLNh3RR1W+g8JWn0ottRhK5LNTtDBVA=";
+            })
+          ];
+        in
+          ourPatches ++ upstreamPatches;
+      });
+
+      wddx =
+        if lib.versionOlder prev.php.version "7.4"
+        then
+          prev.mkExtension {
+            name = "wddx";
+
+            buildInputs = [
+              pkgs.libxml2
+            ];
+
+            internalDeps = [
+              final.extensions.session
+            ];
+
+            configureFlags = [
+              "--enable-wddx"
+              "--with-libxml-dir=${pkgs.libxml2.dev}"
+            ];
+          }
+        else null;
+
+      xdebug =
+        # xdebug versions were determined using https://xdebug.org/docs/compat
+        if lib.versionAtLeast prev.php.version "8.0"
+        then prev.extensions.xdebug
+        else if lib.versionAtLeast prev.php.version "7.2"
+        then
+          prev.extensions.xdebug.overrideAttrs (attrs: {
+            name = "xdebug-3.1.6";
+            version = "3.1.6";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/xdebug-3.1.6.tgz";
+              sha256 = "1lnmrb5kgq8lbhjs48j3wwhqgk44pnqb1yjq4b5r6ysv9l5wlkjm";
+            };
+          })
+        else if lib.versionAtLeast prev.php.version "7.1"
+        then
+          prev.extensions.xdebug.overrideAttrs (attrs: {
+            name = "xdebug-2.9.8";
+            version = "2.9.8";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/xdebug-2.9.8.tgz";
+              sha256 = "12igfrdfisqfmfqpc321g93pm2w1y7h24bclmxjrjv6rb36bcmgm";
+            };
+          })
+        else if lib.versionAtLeast prev.php.version "7.0"
+        then
+          prev.extensions.xdebug.overrideAttrs (attrs: {
             name = "xdebug-2.7.2";
             version = "2.7.2";
             src = pkgs.fetchurl {
@@ -514,87 +520,95 @@ in
               sha256 = "19m40n5h339yk0g458zpbsck1lslhnjsmhrp076kzhl5l4x2iwxh";
             };
           })
-      else
-        prev.extensions.xdebug.overrideAttrs (attrs: {
-          name = "xdebug-2.5.5";
-          version = "2.5.5";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/xdebug-2.5.5.tgz";
-            sha256 = "197i1fcspbrdxki6rljvpjdxzhyaxl7nlihhiqcyfkjipkr8n43j";
-          };
-        });
+        else
+          prev.extensions.xdebug.overrideAttrs (attrs: {
+            name = "xdebug-2.5.5";
+            version = "2.5.5";
+            src = pkgs.fetchurl {
+              url = "http://pecl.php.net/get/xdebug-2.5.5.tgz";
+              sha256 = "197i1fcspbrdxki6rljvpjdxzhyaxl7nlihhiqcyfkjipkr8n43j";
+            };
+          });
 
-    xml = prev.extensions.xml.overrideAttrs (attrs: {
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Required to build on darwin.
-          "--with-libxml-dir=${pkgs.libxml2.dev}"
-        ];
-    });
-
-    xmlreader = prev.extensions.xmlreader.overrideAttrs (attrs: {
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Required to build on darwin.
-          "--with-libxml-dir=${pkgs.libxml2.dev}"
-        ];
-    });
-
-    xmlrpc =
-      if lib.versionOlder prev.php.version "8.0" then
-        prev.mkExtension {
-          name = "xmlrpc";
-          buildInputs = [
-            pkgs.libxml2
-            pkgs.libiconv
-          ];
-          configureFlags = [
-            "--with-xmlrpc"
-          ] ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+      xml = prev.extensions.xml.overrideAttrs (attrs: {
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
             # Required to build on darwin.
             "--with-libxml-dir=${pkgs.libxml2.dev}"
           ];
-        }
-      else
-        null;
+      });
 
-    xmlwriter = prev.extensions.xmlwriter.overrideAttrs (attrs: {
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          # Required to build on darwin.
-          "--with-libxml-dir=${pkgs.libxml2.dev}"
-        ];
-    });
-
-    zip = prev.extensions.zip.overrideAttrs (attrs: {
-      configureFlags =
-        attrs.configureFlags or []
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.3") [
-          "--with-libzip"
-        ]
-        ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
-          "--with-zlib-dir=${pkgs.zlib.dev}"
-        ];
-    });
-
-    zlib = prev.extensions.zlib.overrideAttrs (attrs: {
-      patches =
-        attrs.patches or []
-        ++ lib.optionals (lib.versionAtLeast prev.php.version "7.1" && lib.versionOlder prev.php.version "7.4") [
-          # Fix Darwin build
-          # Introduced in https://github.com/NixOS/nixpkgs/commit/af064a0e12ad8e5a8a2e8d8ad25fc0baf3f8ef54
-          # Derived from https://github.com/php/php-src/commit/f16b012116d6c015632741a3caada5b30ef8a699
-          ./patches/zlib-darwin-tests.patch
-        ];
-
+      xmlreader = prev.extensions.xmlreader.overrideAttrs (attrs: {
         configureFlags =
-          attrs.configureFlags or []
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Required to build on darwin.
+            "--with-libxml-dir=${pkgs.libxml2.dev}"
+          ];
+      });
+
+      xmlrpc =
+        if lib.versionOlder prev.php.version "8.0"
+        then
+          prev.mkExtension {
+            name = "xmlrpc";
+            buildInputs = [
+              pkgs.libxml2
+              pkgs.libiconv
+            ];
+            configureFlags =
+              [
+                "--with-xmlrpc"
+              ]
+              ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+                # Required to build on darwin.
+                "--with-libxml-dir=${pkgs.libxml2.dev}"
+              ];
+          }
+        else null;
+
+      xmlwriter = prev.extensions.xmlwriter.overrideAttrs (attrs: {
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            # Required to build on darwin.
+            "--with-libxml-dir=${pkgs.libxml2.dev}"
+          ];
+      });
+
+      zip = prev.extensions.zip.overrideAttrs (attrs: {
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.3") [
+            "--with-libzip"
+          ]
           ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
             "--with-zlib-dir=${pkgs.zlib.dev}"
           ];
-    });
-  };
+      });
+
+      zlib = prev.extensions.zlib.overrideAttrs (attrs: {
+        patches =
+          attrs.patches
+          or []
+          ++ lib.optionals (lib.versionAtLeast prev.php.version "7.1" && lib.versionOlder prev.php.version "7.4") [
+            # Fix Darwin build
+            # Introduced in https://github.com/NixOS/nixpkgs/commit/af064a0e12ad8e5a8a2e8d8ad25fc0baf3f8ef54
+            # Derived from https://github.com/php/php-src/commit/f16b012116d6c015632741a3caada5b30ef8a699
+            ./patches/zlib-darwin-tests.patch
+          ];
+
+        configureFlags =
+          attrs.configureFlags
+          or []
+          ++ lib.optionals (lib.versionOlder prev.php.version "7.4") [
+            "--with-zlib-dir=${pkgs.zlib.dev}"
+          ];
+      });
+    };
 }

--- a/pkgs/php-cs-fixer/2.x.nix
+++ b/pkgs/php-cs-fixer/2.x.nix
@@ -5,7 +5,6 @@
   lib,
   php,
 }:
-
 mkDerivation rec {
   pname = "php-cs-fixer";
   version = "2.19.0";
@@ -15,8 +14,8 @@ mkDerivation rec {
     sha256 = "sha256-3K91VkeaHPx+zhGiA8QkfWH6voblCbDilTkRH2uCAYw=";
   };
 
-  phases = [ "installPhase" ];
-  nativeBuildInputs = [ makeWrapper ];
+  phases = ["installPhase"];
+  nativeBuildInputs = [makeWrapper];
 
   installPhase = ''
     runHook preInstall
@@ -33,6 +32,6 @@ mkDerivation rec {
     description = "A tool to automatically fix PHP coding standards issues";
     license = licenses.mit;
     homepage = "http://cs.sensiolabs.org/";
-    maintainers = with maintainers; [ jtojnar ] ++ teams.php.members;
+    maintainers = with maintainers; [jtojnar] ++ teams.php.members;
   };
 }

--- a/pkgs/php/5.6.nix
+++ b/pkgs/php/5.6.nix
@@ -1,60 +1,60 @@
-{ prev, mkPhp }:
-
-let
+{
+  prev,
+  mkPhp,
+}: let
   base = mkPhp {
     version = "5.6.40";
     hash = "sha256-/9Al00YjVTqy9/2Psh0Mnm+fow3FZcoDode3YwI/ugA=";
   };
 in
-base.withExtensions (
-  { all, ... }:
-
-  with all; (
-    [
-      bcmath
-      calendar
-      curl
-      ctype
-      dom
-      exif
-      fileinfo
-      filter
-      ftp
-      gd
-      gettext
-      gmp
-      iconv
-      intl
-      json
-      ldap
-      mbstring
-      mysqli
-      mysqlnd
-      opcache
-      openssl
-      pcntl
-      pdo
-      pdo_mysql
-      pdo_odbc
-      pdo_pgsql
-      pdo_sqlite
-      pgsql
-      posix
-      readline
-      session
-      simplexml
-      sockets
-      soap
-      sysvsem
-      sqlite3
-      tokenizer
-      xmlreader
-      xmlwriter
-      zip
-      zlib
-    ]
-    ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
-      imap
-    ]
+  base.withExtensions (
+    {all, ...}:
+      with all; (
+        [
+          bcmath
+          calendar
+          curl
+          ctype
+          dom
+          exif
+          fileinfo
+          filter
+          ftp
+          gd
+          gettext
+          gmp
+          iconv
+          intl
+          json
+          ldap
+          mbstring
+          mysqli
+          mysqlnd
+          opcache
+          openssl
+          pcntl
+          pdo
+          pdo_mysql
+          pdo_odbc
+          pdo_pgsql
+          pdo_sqlite
+          pgsql
+          posix
+          readline
+          session
+          simplexml
+          sockets
+          soap
+          sysvsem
+          sqlite3
+          tokenizer
+          xmlreader
+          xmlwriter
+          zip
+          zlib
+        ]
+        ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
+          imap
+        ]
+      )
   )
-)

--- a/pkgs/php/7.0.nix
+++ b/pkgs/php/7.0.nix
@@ -1,60 +1,60 @@
-{ prev, mkPhp }:
-
-let
+{
+  prev,
+  mkPhp,
+}: let
   base = mkPhp {
     version = "7.0.33";
     hash = "sha256-STPqdCmKG6BGsCRv43cUFchN+4eDliAbVstTM6vobwc=";
   };
 in
-base.withExtensions (
-  { all, ... }:
-
-  with all; (
-    [
-      bcmath
-      calendar
-      curl
-      ctype
-      dom
-      exif
-      fileinfo
-      filter
-      ftp
-      gd
-      gettext
-      gmp
-      iconv
-      intl
-      json
-      ldap
-      mbstring
-      mysqli
-      mysqlnd
-      opcache
-      openssl
-      pcntl
-      pdo
-      pdo_mysql
-      pdo_odbc
-      pdo_pgsql
-      pdo_sqlite
-      pgsql
-      posix
-      readline
-      session
-      simplexml
-      sockets
-      soap
-      sysvsem
-      sqlite3
-      tokenizer
-      xmlreader
-      xmlwriter
-      zip
-      zlib
-    ]
-    ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
-      imap
-    ]
+  base.withExtensions (
+    {all, ...}:
+      with all; (
+        [
+          bcmath
+          calendar
+          curl
+          ctype
+          dom
+          exif
+          fileinfo
+          filter
+          ftp
+          gd
+          gettext
+          gmp
+          iconv
+          intl
+          json
+          ldap
+          mbstring
+          mysqli
+          mysqlnd
+          opcache
+          openssl
+          pcntl
+          pdo
+          pdo_mysql
+          pdo_odbc
+          pdo_pgsql
+          pdo_sqlite
+          pgsql
+          posix
+          readline
+          session
+          simplexml
+          sockets
+          soap
+          sysvsem
+          sqlite3
+          tokenizer
+          xmlreader
+          xmlwriter
+          zip
+          zlib
+        ]
+        ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
+          imap
+        ]
+      )
   )
-)

--- a/pkgs/php/7.1.nix
+++ b/pkgs/php/7.1.nix
@@ -1,60 +1,60 @@
-{ prev, mkPhp }:
-
-let
+{
+  prev,
+  mkPhp,
+}: let
   base = mkPhp {
     version = "7.1.33";
     hash = "sha256-laXl8uK3mzdrc3qC2WgskYkeYCifokGDRjoqyhWPT0s=";
   };
 in
-base.withExtensions (
-  { all, ... }:
-
-  with all; (
-    [
-      bcmath
-      calendar
-      curl
-      ctype
-      dom
-      exif
-      fileinfo
-      filter
-      ftp
-      gd
-      gettext
-      gmp
-      iconv
-      intl
-      json
-      ldap
-      mbstring
-      mysqli
-      mysqlnd
-      opcache
-      openssl
-      pcntl
-      pdo
-      pdo_mysql
-      pdo_odbc
-      pdo_pgsql
-      pdo_sqlite
-      pgsql
-      posix
-      readline
-      session
-      simplexml
-      sockets
-      soap
-      sysvsem
-      sqlite3
-      tokenizer
-      xmlreader
-      xmlwriter
-      zip
-      zlib
-    ]
-    ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
-      imap
-    ]
+  base.withExtensions (
+    {all, ...}:
+      with all; (
+        [
+          bcmath
+          calendar
+          curl
+          ctype
+          dom
+          exif
+          fileinfo
+          filter
+          ftp
+          gd
+          gettext
+          gmp
+          iconv
+          intl
+          json
+          ldap
+          mbstring
+          mysqli
+          mysqlnd
+          opcache
+          openssl
+          pcntl
+          pdo
+          pdo_mysql
+          pdo_odbc
+          pdo_pgsql
+          pdo_sqlite
+          pgsql
+          posix
+          readline
+          session
+          simplexml
+          sockets
+          soap
+          sysvsem
+          sqlite3
+          tokenizer
+          xmlreader
+          xmlwriter
+          zip
+          zlib
+        ]
+        ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
+          imap
+        ]
+      )
   )
-)

--- a/pkgs/php/7.2.nix
+++ b/pkgs/php/7.2.nix
@@ -1,61 +1,61 @@
-{ prev, mkPhp }:
-
-let
+{
+  prev,
+  mkPhp,
+}: let
   base = mkPhp {
     version = "7.2.34";
     hash = "sha256-DlgW1miiuxSspozvjEMEML2Gw8UjP2xCfRpUqsEnq88=";
   };
 in
-base.withExtensions (
-  { all, ... }:
-
-  with all; (
-    [
-      bcmath
-      calendar
-      curl
-      ctype
-      dom
-      exif
-      fileinfo
-      filter
-      ftp
-      gd
-      gettext
-      gmp
-      iconv
-      intl
-      json
-      ldap
-      mbstring
-      mysqli
-      mysqlnd
-      opcache
-      openssl
-      pcntl
-      pdo
-      pdo_mysql
-      pdo_odbc
-      pdo_pgsql
-      pdo_sqlite
-      pgsql
-      posix
-      readline
-      session
-      simplexml
-      sockets
-      soap
-      sodium
-      sysvsem
-      sqlite3
-      tokenizer
-      xmlreader
-      xmlwriter
-      zip
-      zlib
-    ]
-    ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
-      imap
-    ]
+  base.withExtensions (
+    {all, ...}:
+      with all; (
+        [
+          bcmath
+          calendar
+          curl
+          ctype
+          dom
+          exif
+          fileinfo
+          filter
+          ftp
+          gd
+          gettext
+          gmp
+          iconv
+          intl
+          json
+          ldap
+          mbstring
+          mysqli
+          mysqlnd
+          opcache
+          openssl
+          pcntl
+          pdo
+          pdo_mysql
+          pdo_odbc
+          pdo_pgsql
+          pdo_sqlite
+          pgsql
+          posix
+          readline
+          session
+          simplexml
+          sockets
+          soap
+          sodium
+          sysvsem
+          sqlite3
+          tokenizer
+          xmlreader
+          xmlwriter
+          zip
+          zlib
+        ]
+        ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
+          imap
+        ]
+      )
   )
-)

--- a/pkgs/php/7.3.nix
+++ b/pkgs/php/7.3.nix
@@ -1,71 +1,70 @@
-{ prev, mkPhp }:
-
-let
+{
+  prev,
+  mkPhp,
+}: let
   base = mkPhp {
     version = "7.3.28";
     hash = "sha256-j2NuZEWUOIQ26gX/NMnrE15twRnBEwGZ6UiNV5VDmWQ=";
 
-    extraPatches =
-      prev.lib.optionals prev.stdenv.isDarwin [
-        # Fix build on Darwin
-        # https://bugs.php.net/bug.php?id=76826
-        (prev.fetchurl {
-          url = "https://github.com/NixOS/nixpkgs/raw/42e9a2ccfab2a96d28c3c164a6cf41fb6f769de5/pkgs/development/interpreters/php/php73-darwin-isfinite.patch";
-          sha256 = "V0mLLmXa2qJyxIVW/7nEml6cXZTBbr42kkJiij9KPyk=";
-        })
+    extraPatches = prev.lib.optionals prev.stdenv.isDarwin [
+      # Fix build on Darwin
+      # https://bugs.php.net/bug.php?id=76826
+      (prev.fetchurl {
+        url = "https://github.com/NixOS/nixpkgs/raw/42e9a2ccfab2a96d28c3c164a6cf41fb6f769de5/pkgs/development/interpreters/php/php73-darwin-isfinite.patch";
+        sha256 = "V0mLLmXa2qJyxIVW/7nEml6cXZTBbr42kkJiij9KPyk=";
+      })
     ];
   };
 in
-base.withExtensions (
-  { all, ... }:
-
-  with all; (
-    [
-      bcmath
-      calendar
-      curl
-      ctype
-      dom
-      exif
-      fileinfo
-      filter
-      ftp
-      gd
-      gettext
-      gmp
-      iconv
-      intl
-      json
-      ldap
-      mbstring
-      mysqli
-      mysqlnd
-      opcache
-      openssl
-      pcntl
-      pdo
-      pdo_mysql
-      pdo_odbc
-      pdo_pgsql
-      pdo_sqlite
-      pgsql
-      posix
-      readline
-      session
-      simplexml
-      sockets
-      soap
-      sodium
-      sysvsem
-      sqlite3
-      tokenizer
-      xmlreader
-      xmlwriter
-      zip
-      zlib
-    ]
-    ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
-      imap
-    ]
+  base.withExtensions (
+    {all, ...}:
+      with all; (
+        [
+          bcmath
+          calendar
+          curl
+          ctype
+          dom
+          exif
+          fileinfo
+          filter
+          ftp
+          gd
+          gettext
+          gmp
+          iconv
+          intl
+          json
+          ldap
+          mbstring
+          mysqli
+          mysqlnd
+          opcache
+          openssl
+          pcntl
+          pdo
+          pdo_mysql
+          pdo_odbc
+          pdo_pgsql
+          pdo_sqlite
+          pgsql
+          posix
+          readline
+          session
+          simplexml
+          sockets
+          soap
+          sodium
+          sysvsem
+          sqlite3
+          tokenizer
+          xmlreader
+          xmlwriter
+          zip
+          zlib
+        ]
+        ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
+          imap
+        ]
+      )
   )
-)

--- a/pkgs/php/7.4.nix
+++ b/pkgs/php/7.4.nix
@@ -1,61 +1,61 @@
-{ prev, mkPhp }:
-
-let
+{
+  prev,
+  mkPhp,
+}: let
   base = mkPhp {
     version = "7.4.33";
     hash = "sha256-ToEXRY/lpHW/IDEocmtxvLumHEKtRj3/re5WZ6GYqYo=";
   };
 in
-base.withExtensions (
-  { all, ... }:
-
-  with all; (
-    [
-      bcmath
-      calendar
-      curl
-      ctype
-      dom
-      exif
-      fileinfo
-      filter
-      ftp
-      gd
-      gettext
-      gmp
-      iconv
-      intl
-      json
-      ldap
-      mbstring
-      mysqli
-      mysqlnd
-      opcache
-      openssl
-      pcntl
-      pdo
-      pdo_mysql
-      pdo_odbc
-      pdo_pgsql
-      pdo_sqlite
-      pgsql
-      posix
-      readline
-      session
-      simplexml
-      sockets
-      soap
-      sodium
-      sysvsem
-      sqlite3
-      tokenizer
-      xmlreader
-      xmlwriter
-      zip
-      zlib
-    ]
-    ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
-      imap
-    ]
+  base.withExtensions (
+    {all, ...}:
+      with all; (
+        [
+          bcmath
+          calendar
+          curl
+          ctype
+          dom
+          exif
+          fileinfo
+          filter
+          ftp
+          gd
+          gettext
+          gmp
+          iconv
+          intl
+          json
+          ldap
+          mbstring
+          mysqli
+          mysqlnd
+          opcache
+          openssl
+          pcntl
+          pdo
+          pdo_mysql
+          pdo_odbc
+          pdo_pgsql
+          pdo_sqlite
+          pgsql
+          posix
+          readline
+          session
+          simplexml
+          sockets
+          soap
+          sodium
+          sysvsem
+          sqlite3
+          tokenizer
+          xmlreader
+          xmlwriter
+          zip
+          zlib
+        ]
+        ++ prev.lib.optionals (!prev.stdenv.isDarwin) [
+          imap
+        ]
+      )
   )
-)

--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -1,16 +1,9 @@
 nixpkgs:
-
 # These are older versions of PHP removed from Nixpkgs.
-
-final:
-prev:
-
-let
+final: prev: let
   packageOverrides = import ./package-overrides.nix prev;
 
-  _mkArgs =
-    args:
-
+  _mkArgs = args:
     {
       inherit packageOverrides;
 
@@ -20,121 +13,115 @@ let
         then prev.pcre2
         else prev.pcre;
 
-      phpAttrsOverrides =
-        attrs:
+      phpAttrsOverrides = attrs: {
+        patches =
+          attrs.patches
+          or []
+          ++ prev.lib.optionals (prev.lib.versions.majorMinor args.version == "7.2") [
+            # Building the bundled intl extension fails on Mac OS.
+            # See https://bugs.php.net/bug.php?id=76826 for more information.
+            (prev.pkgs.fetchpatch {
+              url = "https://bugs.php.net/patch-display.php?bug_id=76826&patch=bug76826.poc.0.patch&revision=1538723399&download=1";
+              sha256 = "aW+MW9Kb8N/yBO7MdqZMZzgMSF7b+IMLulJKgKPWrUA=";
+            })
+          ]
+          ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.4") [
+            # Handle macos versions that don't start with 10.* in libtool.
+            # https://github.com/php/php-src/commit/d016434ad33284dfaceb8d233351d34356566d7d
+            (prev.pkgs.fetchpatch2 {
+              url = "https://github.com/php/php-src/commit/d016434ad33284dfaceb8d233351d34356566d7d.patch";
+              sha256 = "sha256-x0vEcoXNFeQi3re1TrK/Np9AH5dy3wf95xM08xCyGE0=";
+              includes = [
+                "build/libtool.m4"
+              ];
+            })
+          ];
 
-        {
-          patches =
-            attrs.patches or []
-            ++ prev.lib.optionals (prev.lib.versions.majorMinor args.version == "7.2") [
-              # Building the bundled intl extension fails on Mac OS.
-              # See https://bugs.php.net/bug.php?id=76826 for more information.
-              (prev.pkgs.fetchpatch {
-                url = "https://bugs.php.net/patch-display.php?bug_id=76826&patch=bug76826.poc.0.patch&revision=1538723399&download=1";
-                sha256 = "aW+MW9Kb8N/yBO7MdqZMZzgMSF7b+IMLulJKgKPWrUA=";
-              })
-            ]
-            ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.4") [
-              # Handle macos versions that don't start with 10.* in libtool.
-              # https://github.com/php/php-src/commit/d016434ad33284dfaceb8d233351d34356566d7d
-              (prev.pkgs.fetchpatch2 {
-                url = "https://github.com/php/php-src/commit/d016434ad33284dfaceb8d233351d34356566d7d.patch";
-                sha256 = "sha256-x0vEcoXNFeQi3re1TrK/Np9AH5dy3wf95xM08xCyGE0=";
-                includes = [
-                  "build/libtool.m4"
-                ];
-              })
-            ];
+        configureFlags =
+          attrs.configureFlags
+          ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.4") [
+            # phar extension’s build system expects hash or it will degrade.
+            "--enable-hash"
 
-          configureFlags =
-            attrs.configureFlags
-            ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.4") [
-              # phar extension’s build system expects hash or it will degrade.
-              "--enable-hash"
+            "--enable-libxml"
+            "--with-libxml-dir=${prev.libxml2.dev}"
+          ]
+          ++ prev.lib.optionals (prev.lib.versions.majorMinor args.version == "7.3") [
+            # Force use of pkg-config.
+            # https://github.com/php/php-src/blob/php-7.3.33/ext/pcre/config0.m4#L14
+            "--with-pcre-regex=/usr"
+          ]
+          ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.3") [
+            # Only PCRE 1 supported and no pkg-config.
+            "--with-pcre-regex=${prev.pcre.dev}"
+            "PCRE_LIBDIR=${prev.pcre}"
+          ];
 
-              "--enable-libxml"
-              "--with-libxml-dir=${prev.libxml2.dev}"
-            ]
-            ++ prev.lib.optionals (prev.lib.versions.majorMinor args.version == "7.3") [
-              # Force use of pkg-config.
-              # https://github.com/php/php-src/blob/php-7.3.33/ext/pcre/config0.m4#L14
-              "--with-pcre-regex=/usr"
-            ]
-            ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.3") [
-              # Only PCRE 1 supported and no pkg-config.
-              "--with-pcre-regex=${prev.pcre.dev}"
-              "PCRE_LIBDIR=${prev.pcre}"
-            ];
+        buildInputs =
+          attrs.buildInputs
+          ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.1") [
+            prev.libxcrypt
+          ];
 
-          buildInputs =
-            attrs.buildInputs
-            ++ prev.lib.optionals (prev.lib.versionOlder args.version "7.1") [
-              prev.libxcrypt
-            ];
-
-          preConfigure =
-            prev.lib.optionalString (prev.lib.versionOlder args.version "7.4") ''
-              # Workaround “configure: error: Your system does not support systemd.”
-              # caused by PHP build system expecting PKG_CONFIG variable to contain
-              # an absolute path on PHP ≤ 7.4.
-              # Also patches acinclude.m4, which ends up being used by extensions.
-              # https://github.com/NixOS/nixpkgs/pull/90249
-              for i in $(find . -type f -name "*.m4"); do
-                substituteInPlace $i \
-                  --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
-              done
-            ''
-            + attrs.preConfigure;
-        };
+        preConfigure =
+          prev.lib.optionalString (prev.lib.versionOlder args.version "7.4") ''
+            # Workaround “configure: error: Your system does not support systemd.”
+            # caused by PHP build system expecting PKG_CONFIG variable to contain
+            # an absolute path on PHP ≤ 7.4.
+            # Also patches acinclude.m4, which ends up being used by extensions.
+            # https://github.com/NixOS/nixpkgs/pull/90249
+            for i in $(find . -type f -name "*.m4"); do
+              substituteInPlace $i \
+                --replace 'test -x "$PKG_CONFIG"' 'type -P "$PKG_CONFIG" >/dev/null'
+            done
+          ''
+          + attrs.preConfigure;
+      };
 
       # For passing pcre2 to php-packages.nix.
-      callPackage =
-        cpFn:
-        cpArgs:
-
+      callPackage = cpFn: cpArgs:
         prev.callPackage
-          cpFn
-          (
-            cpArgs
-            // {
-              pcre2 =
-                if prev.lib.versionAtLeast args.version "7.3"
-                then prev.pcre2
-                else prev.pcre;
+        cpFn
+        (
+          cpArgs
+          // {
+            pcre2 =
+              if prev.lib.versionAtLeast args.version "7.3"
+              then prev.pcre2
+              else prev.pcre;
 
-              # For passing pcre2 to stuff called with callPackage in php-packages.nix.
-              pkgs =
-                prev
-                // (
-                  prev.lib.makeScope
-                    prev.newScope
-                    (self: {
-                      pcre2 =
-                        if prev.lib.versionAtLeast args.version "7.3"
-                        then prev.pcre2
-                        else prev.pcre;
-                    })
-                );
-            }
-          );
+            # For passing pcre2 to stuff called with callPackage in php-packages.nix.
+            pkgs =
+              prev
+              // (
+                prev.lib.makeScope
+                prev.newScope
+                (self: {
+                  pcre2 =
+                    if prev.lib.versionAtLeast args.version "7.3"
+                    then prev.pcre2
+                    else prev.pcre;
+                })
+              );
+          }
+        );
     }
     // args;
 
   generic = "${nixpkgs}/pkgs/development/interpreters/php/generic.nix";
   mkPhp = args: prev.callPackage generic (_mkArgs args);
-in
-{
-  php56 = import ./php/5.6.nix { inherit prev mkPhp; };
+in {
+  php56 = import ./php/5.6.nix {inherit prev mkPhp;};
 
-  php70 = import ./php/7.0.nix { inherit prev mkPhp; };
+  php70 = import ./php/7.0.nix {inherit prev mkPhp;};
 
-  php71 = import ./php/7.1.nix { inherit prev mkPhp; };
+  php71 = import ./php/7.1.nix {inherit prev mkPhp;};
 
-  php72 = import ./php/7.2.nix { inherit prev mkPhp; };
+  php72 = import ./php/7.2.nix {inherit prev mkPhp;};
 
-  php73 = import ./php/7.3.nix { inherit prev mkPhp; };
+  php73 = import ./php/7.3.nix {inherit prev mkPhp;};
 
-  php74 = import ./php/7.4.nix { inherit prev mkPhp; };
+  php74 = import ./php/7.4.nix {inherit prev mkPhp;};
 
   php80 = prev.php80.override {
     inherit packageOverrides;


### PR DESCRIPTION
This PR:

- [x] add a default formatter in the flake output, I used `alejandra`
- [x] add a new Github action workflow checking if running the formatter hasn't changed the files (the `--dry-run` hasn't been implemented yet, see https://github.com/NixOS/nix/issues/6918)