### PR TITLE
ci/editorconfig: Update the action to HEAD

### DIFF
--- a/.github/workflows/editorconfig-checks.yaml
+++ b/.github/workflows/editorconfig-checks.yaml
@@ -11,4 +11,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check files for EditorConfig compliance
-        uses: editorconfig-checker/action-editorconfig-checker@v1
+        uses: editorconfig-checker/action-editorconfig-checker@d4fca16fc71adef10fbe101903b654449fa9570c # untagged main
+        with:
+          version: 2.7.0


### PR DESCRIPTION
The action recently started checking `.git/config`, causing the workflow to fail.
This is likely caused by the recent bump of editorconfig’s Docker image from 2.4.0 to 2.7.0.

Curiously, the issue does not occur when using 2.7.0 via the action from the main branch so let’s switch to that, pinning the commit since there is no tag yet.
While at it, let’s also pin the editorconfig version to reduce the change of possible breakage in the future.
