### PR TITLE
fix: only apply opcache `postPatch` for PHP < 7.2 and on Darwin.

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -317,6 +317,9 @@ in
           ./patches/zend_file_cache_config.patch
         ];
 
+      postPatch = if (lib.versionAtLeast prev.php.version "7.2" && pkgs.stdenv.isDarwin) then
+        attrs.postPatch else '''';
+
       doCheck = lib.versionAtLeast prev.php.version "7.4";
     });
 


### PR DESCRIPTION
This issue first appeared here: https://github.com/loophp/nix-shell/actions/runs/4200834200/jobs/7287266267

```
building '/nix/store/8jr2w0c1ypwx286dk7sgjr3bglspsqi3-php-openssl-7.1.33.drv'...
error: builder for '/nix/store/cslb2nwi3zvxmy2rzgzccxp5hz90mqmi-php-opcache-7.1.33.drv' failed with exit code 1;
       last 10 log lines:
       > unpacking source archive /nix/store/g96m8y68s2sayszmijlqdrhsy4wj84d2-php-7.1.33.tar.bz2
       > source root is php-7.1.33
       > setting SOURCE_DATE_EPOCH to timestamp 1571763603 of file php-7.1.33/vcsclean
       > patching sources
       > applying patch /nix/store/gg2z4qpg0vqighpncbb3f4271j4bj7wn-zend_file_cache_config.patch
       > patching file ext/opcache/zend_file_cache.c
       > patch unexpectedly ends in middle of line
       > Hunk #1 succeeded at 27 with fuzz 1.
       > rm: cannot remove 'ext/opcache/tests/bug78106.phpt': No such file or directory
       > /nix/store/32knm2y5g4x541xav6r6y7rhij8cg7lx-stdenv-darwin/setup: line 138: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/cslb2nwi3zvxmy2rzgzccxp5hz90mqmi-php-opcache-7.1.33.drv'.
```

This PR alter the `opcache` extension and make sure that `postPatch` is only applied only on PHP < 7.2 and when environment is Darwin. 

See this temporary PR to show that this patch is working: https://github.com/loophp/nix-shell/pull/131