### PR TITLE
php≤71.extensions.opcache: Fix build on Darwin

### DIFF
--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2023 Jan Tojnar <jtojnar@gmail.com>
+# SPDX-License-Identifier: MIT
+
+{
+  lib,
+}:
+
+{
+  /** Remove given lines from a string.
+
+    Will fail loudly if any of the lines is not present.
+
+    Type: removeLines :: [string] -> string -> string
+
+    Complexity: O(|lines| × |string|)
+  */
+  removeLines =
+    lines:
+    string:
+
+    let
+      lineRegexp = line: "(.*)(^|\n)" + lib.escapeRegex line + "($|\n)(.*)";
+      isLinePresent = line: haystack: builtins.match (lineRegexp line) haystack != null;
+      lineAssertion = line: haystack: lib.assertMsg (isLinePresent line haystack) ("Unable to remove line “" + line + "”, it is not present in “" + haystack + "”.");
+      removeLine =
+        string:
+        line:
+
+        let
+          result = builtins.match (lineRegexp line) string;
+          linesBefore = builtins.elemAt result 0;
+          separatorBefore = builtins.elemAt result 1;
+          separatorAfter = builtins.elemAt result 2;
+          linesAfter = builtins.elemAt result 3;
+        in
+          linesBefore + (if separatorBefore != "" then separatorBefore else separatorAfter) + linesAfter;
+    in
+
+    assert builtins.all (line: lineAssertion line string) lines;
+
+    lib.foldl removeLine string lines;
+}

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -18,6 +18,8 @@ let
   '';
 
   inherit (pkgs) lib;
+
+  inherit (import ./lib.nix { inherit lib; }) removeLines;
 in
 
 {
@@ -318,6 +320,13 @@ in
         ];
 
       doCheck = lib.versionAtLeast prev.php.version "7.4";
+
+      postPatch =
+        removeLines
+          (lib.optionals (lib.versionOlder prev.php.version "7.2.20" && pkgs.stdenv.isDarwin) [
+            "rm ext/opcache/tests/bug78106.phpt"
+          ])
+          attrs.postPatch;
     });
 
     openssl = prev.extensions.openssl.overrideAttrs (attrs: {


### PR DESCRIPTION
Nixpkgs disables some opcache tests on Darwin by removing them:
https://github.com/NixOS/nixpkgs/commit/7a09daa9139d543129a56f50b74e152843579f3e

But the test was only introduced in 7.2.20 so we cannot remove it in older versions:
https://github.com/php/php-src/commit/42c7d5106b03e0a07cfa6f40ed2d883575d6fcc3

It would cause “No such file or directory” error.

Let’s remove the line on affected PHP versions.
Using `removeLines` will let us know loudly when the removal is no longer necessary.

Supersedes https://github.com/fossar/nix-phps/pull/212
