### PR TITLE
ci: bump `cachix/install-nix-action`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v20
 
       - name: Set up Nix cache
         uses: cachix/cachix-action@v12


### PR DESCRIPTION
Also fix `cachix/cachix-action` version number

Context: https://discourse.nixos.org/t/nix-2-14-0-released/25900/4?u=drupol