### PR TITLE
php: remove `meta.knownVulnerabilities`

### DIFF
--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -124,6 +124,10 @@ let
   mkPhp = args: prev.callPackage generic (_mkArgs args);
 in
 {
+  openssl_1_1 = prev.openssl_1_1.overrideAttrs (old: {
+    meta = builtins.removeAttrs old.meta [ "knownVulnerabilities" ];
+  });
+
   php56 = import ./php/5.6.nix { inherit prev mkPhp; };
 
   php70 = import ./php/7.0.nix { inherit prev mkPhp; };


### PR DESCRIPTION
This PR:

- [x] Is related to #231 
- [x] Override the `openssl_1_1` derivation to remove the `knownVulnerabilities` in OpenSSL 1.1 (https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/openssl/default.nix#L236)