### PR TITLE
extensions: fix extensions handling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,10 @@ jobs:
       - name: Build PHP
         run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-php
 
+      - name: List extensions
+        run: |
+          nix eval --json --impure --expr 'builtins.attrNames (import ./.).packages.x86_64-linux.${{ steps.params.outputs.attr }}.extensions'
+
       - name: Build Imagick extension
         run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-imagick
 


### PR DESCRIPTION
Listing available extensions for a PHP derivations is currently broken.

Reasons are:

1. Syntax errors
2. Wrong way of handling extensions
3. Missing upstream extension, not defined in here

Therefore, the idea behind this PR is to be able to list all the available extensions for any `php` derivations, without errors.

Doing (replace `XX` with the PHP version): 

```shell
NIXPKGS_ALLOW_BROKEN=1 \
NIXPKGS_ALLOW_INSECURE=1 \
NIXPKGS_ALLOW_UNFREE=1 \
nix eval --json --impure --expr '(import ./.).packages.x86_64-linux.phpXX.extensions'
```

should not throw any error, just list the available extensions.

This PR:

- Fix #245 