### PR TITLE
blackfire: fix typo in PHP version

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -72,7 +72,7 @@ in
         prev.extensions.ast;
 
     blackfire =
-      if lib.versionAtLeast prev.php.version "80" then
+      if lib.versionAtLeast prev.php.version "8.0" then
         prev.extensions.blackfire
       else
         throw "php.extensions.blackfire requires PHP version >= 8.0.";


### PR DESCRIPTION
Issue introduced in #246 

I still don't get why doing:

```shell
nix build --impure --expr '(import ./.).outputs.packages.${builtins.currentSystem}.php82.withExtensions({ enabled, all }: (enabled ++ all.blackfire))'
```

result in:

![image](https://github.com/fossar/nix-phps/assets/252042/24551edf-d6d2-4dfd-8266-c9e7ab6452fe)
