### PR TITLE
phpExtensions.blackfire: restore on PHP 8.0

### DIFF
--- a/pkgs/extensions/blackfire/1.50.0.nix
+++ b/pkgs/extensions/blackfire/1.50.0.nix
@@ -1,0 +1,56 @@
+{
+  stdenv,
+  pkgs,
+  prev
+}:
+
+let
+  version = "1.50.0";
+
+  hashes = {
+    "x86_64-linux" = {
+      system = "amd64";
+      hash = {
+        "5.6" = "sha256-QdhhSMn2fexoC8XkO8XvsXsmu6rpcnB/7Zvr1ALW/SE=";
+      };
+    };
+    "i686-linux" = {
+      system = "i386";
+      hash = {
+        "5.6" = "sha256-0G9ay5fv84xoNICyfgQeHKFm16ltxAKAa6VGA2d+02E=";
+      };
+    };
+    "aarch64-linux" = {
+      system = "arm64";
+      hash = {
+        "5.6" = "sha256-O8ymnzeoXsNl1CxVOTyYmrBlz6YU+T+5W5lQwA5uulM=";
+      };
+    };
+    "aarch64-darwin" = {
+      system = "arm64";
+      hash = {};
+    };
+    "x86_64-darwin" = {
+      system = "amd64";
+      hash = {};
+    };
+  };
+
+  makeSource = { system, phpMajor }:
+    let
+      isLinux = builtins.match ".+-linux" system != null;
+    in
+    assert !isLinux -> (phpMajor != null);
+    pkgs.fetchurl {
+      url = "https://packages.blackfire.io/binaries/blackfire-php/${version}/blackfire-php-${if isLinux then "linux" else "darwin"}_${hashes.${system}.system}-php-${builtins.replaceStrings [ "." ] [ "" ] phpMajor}.so";
+      hash = hashes.${system}.hash.${phpMajor} or (throw "php.extensions.blackfire unsupported on PHP ${phpMajor} on ${system}");
+    };
+in
+prev.extensions.blackfire.overrideAttrs (attrs: {
+  inherit version;
+
+  src = makeSource {
+    system = stdenv.hostPlatform.system;
+    phpMajor = pkgs.lib.versions.majorMinor prev.php.version;
+  };
+})

--- a/pkgs/extensions/blackfire/1.88.1.nix
+++ b/pkgs/extensions/blackfire/1.88.1.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  pkgs,
+  prev
+}:
+
+let
+  version = "1.88.1";
+
+  hashes = {
+    "x86_64-linux" = {
+      system = "amd64";
+      hash = {
+        "8.0" = "sha256-ZxtXJL7fKMxZeRYFr+CX6UnyN1i8RP+BxRQAIQyY/Ko=";
+        "7.4" = "sha256-NEj77n1T4nnEW2XTxvWNaZnEd1IOw+xtVe4v9CSKuJk=";
+        "7.3" = "sha256-9WLqOSxs235Nuxv+dThVoHGdNGqEhXkHRz3gUxt772Q=";
+        "7.2" = "sha256-WQ95ZpjrtTcEc4g+aBWPEkUSopLu3CnABZ+2pr1NkfU=";
+        "7.1" = "sha256-KggDQONObIjOMb13ZSjKuKUMnhQ55vtO64YVw6o3pe8=";
+        "7.0" = "sha256-aix46KUQq7YOtilNpwUW7aHtG3K1MxT1vCGF6dHB2V4=";
+      };
+    };
+    "i686-linux" = {
+      system = "i386";
+      hash = {
+        "8.0" = "sha256-bq0ta1pYMI7y+lxZMlBnB2ug/m3W4bNlnEPG+jvt/78=";
+        "7.4" = "sha256-sVqjVQl6YRSUnw4sFf3hkrsrEO05/iydVwu5FAVjJl4=";
+        "7.3" = "sha256-+d3sVGyfrnXDYWujEFpfzYZW6d3zNDWvloUCaZLdpHM=";
+        "7.2" = "sha256-4yOTaWVnqwqCtnyjXQ8HFTTNIFdVvIxyoevWAjwBSfI=";
+        "7.1" = "sha256-S2knXTVdPSPceNYu1GpdcvdRTdesGRhMDB3+01nYEE0=";
+        "7.0" = "sha256-Wbg7znNLQE8+C7VYRN7AyAMJHtfbnOdbsenTZAp96KM=";
+      };
+    };
+    "aarch64-linux" = {
+      system = "arm64";
+      hash = {
+        "8.0" = "sha256-LUgVmsUpMy4vt2Jv0/t8hrGKsIcyB5Dc058k1qihAN4=";
+        "7.4" = "sha256-i8RlRpLUC2l+m+8AcncWWHPSyakP02s3pTveEHNdsCI=";
+        "7.3" = "sha256-dgQcS7YMk1xbMy3DSgC11WBgNWHfXh1odrE5A0YQY7w=";
+        "7.2" = "sha256-nSthmVtxbpO/pn+nFCuJ9Ncoec7apTPtMnIFh8TiQOg=";
+        "7.1" = "sha256-ky5Zg/zFyEwjHXxa+kcySzqPPwjAILRL+2GX1CdFs8s=";
+        "7.0" = "sha256-wTKM5zXhTS6um2EaIGO5ea0J+dFWXOX/sIqAOcu22yw=";
+      };
+    };
+    "aarch64-darwin" = {
+      system = "arm64";
+      hash = {
+        "8.0" = "sha256-gfdn7oMdpzXVqSgOiczTXTObiGsRb9LnV1Orthnp5iw=";
+        "7.4" = "sha256-t1yPoZFlUmGpI/nIDC4dHTHXnBfZjjJD4N4B8Pj4jjQ=";
+        "7.3" = "sha256-SLrkqiECJzLYeXhQQfwqlOiDVATbsH2dVFoUL+K0u4w=";
+        "7.2" = "sha256-boZ9BwldsWUEUuXBgyC++JKvPfPx3LJysEo5y8e9SAg=";
+        # "7.1" = ""; # Not supported
+        # "7.0" = ""; # Not supported
+      };
+    };
+    "x86_64-darwin" = {
+      system = "amd64";
+      hash = {
+        "8.0" = "sha256-oribKvVNHCH0xULwFPX/aNIKOACdRQDV5W+vk7z/32Q=";
+        "7.4" = "sha256-77GKjMt0CUZbJa8G01sswhtX5lfdthJ5XrzOM0S3feM=";
+        "7.3" = "sha256-Wk253WRciZGXDrVsEhR97D+n0Z2txh+ZST8UpWMAwcM=";
+        "7.2" = "sha256-ftePatTbxglB7NRoqvF3y46ZLrIlBQRfeOkART1okR0=";
+        "7.1" = "sha256-NTD5XRvsxdvezHxm/XOX2edsF6ToHhoTIk8LLNmgHq0=";
+        "7.0" = "sha256-VSQuNQDWSwHgb6xedKwWWJay18zv6YClLrOxxQSMZZ8=";
+      };
+    };
+  };
+
+  makeSource = { system, phpMajor }:
+    let
+      isLinux = builtins.match ".+-linux" system != null;
+    in
+    assert !isLinux -> (phpMajor != null);
+    pkgs.fetchurl {
+      url = "https://packages.blackfire.io/binaries/blackfire-php/${version}/blackfire-php-${if isLinux then "linux" else "darwin"}_${hashes.${system}.system}-php-${builtins.replaceStrings [ "." ] [ "" ] phpMajor}.so";
+      hash = hashes.${system}.hash.${phpMajor} or (throw "php.extensions.blackfire unsupported on PHP ${phpMajor} on ${system}");
+    };
+in
+prev.extensions.blackfire.overrideAttrs (attrs: {
+  inherit version;
+
+  src = makeSource {
+    system = stdenv.hostPlatform.system;
+    phpMajor = pkgs.lib.versions.majorMinor prev.php.version;
+  };
+})

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -72,10 +72,14 @@ in
         prev.extensions.ast;
 
     blackfire =
-      if lib.versionAtLeast prev.php.version "8.0" then
+      if lib.versionAtLeast prev.php.version "8.3" then
+        throw "php.extensions.blackfire requires PHP version >= 5.6 and < 8.3"
+      else if lib.versionAtLeast prev.php.version "8.1" then
         prev.extensions.blackfire
+      else if lib.versionAtLeast prev.php.version "7.0" then
+        final.callPackage ./extensions/blackfire/1.88.1.nix { inherit prev; }
       else
-        throw "php.extensions.blackfire requires PHP version >= 8.0.";
+        final.callPackage ./extensions/blackfire/1.50.0.nix { inherit prev; };
 
     couchbase = prev.extensions.couchbase.overrideAttrs (attrs: {
       preConfigure =


### PR DESCRIPTION
Goal of this PR:

- Restore `blackfire` extension for PHP 8.0 since it has been removed in https://github.com/NixOS/nixpkgs/pull/239228 and https://github.com/NixOS/nixpkgs/pull/239049

This command should be successful: `nix build .#php80.extensions.blackfire`

It was failing because the `finalAttrs` pattern hasn't been implemented.

I made a PR to implement it here https://github.com/NixOS/nixpkgs/pull/241072, once that PR is propagated to `nixpkgs-unstable` (https://nixpk.gs/pr-tracker.html?pr=241072), we can revisit this PR.

Related PR: https://github.com/NixOS/nixpkgs/pull/241543