### PR TITLE
extensions: fix `enchant` extension for PHP < 8

### DIFF
--- a/pkgs/enchant/1.x.nix
+++ b/pkgs/enchant/1.x.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  aspell,
+  pkg-config,
+  glib,
+  hunspell,
+  hspell
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "enchant";
+  version = "1.6.1";
+
+  src = fetchurl {
+    url = "https://github.com/AbiWord/enchant/releases/download/enchant-${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}/enchant-${finalAttrs.version}.tar.gz";
+    hash = "sha256-vvDZwP7y5Oh0aVa2jk1sZkH2uFvSkI2Rcx77aOup4/U=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    aspell
+    glib
+    hunspell
+    hspell
+  ];
+
+  meta = {
+    description = "Generic spell checking library";
+    homepage = "https://abiword.github.io/enchant";
+    license = lib.licenses.lgpl21Only;
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -149,6 +149,21 @@ in
         attrs.preConfigure or "" + linkInternalDeps deps;
     });
 
+    enchant = let
+      enchant1 = pkgs.callPackage ./enchant/1.x.nix { };
+    in
+    prev.extensions.enchant.overrideAttrs (attrs: {
+      buildInputs = attrs.buildInputs or [] ++
+        lib.optionals (lib.versionOlder prev.php.version "8.0") [
+          enchant1
+        ];
+
+      configureFlags = attrs.configureFlags or [] ++
+        lib.optionals (lib.versionOlder prev.php.version "8.0") [
+          "--with-enchant=${lib.getDev enchant1}"
+        ];
+    });
+
     ffi =
       if lib.versionAtLeast prev.php.version "7.4" then
         prev.extensions.ffi


### PR DESCRIPTION
This PR

- Should fix #247

Source of `enchant1` derivation: https://github.com/matthewbauer/nixpkgs/blob/ba76fa91c762160e0d75a4cba74b44a0c3f911e7/pkgs/development/libraries/enchant/1.x.nix