### PR TITLE
extensions: `enchant`: fix build on darwin

### DIFF
--- a/pkgs/enchant/1.x.nix
+++ b/pkgs/enchant/1.x.nix
@@ -29,6 +29,14 @@ stdenv.mkDerivation (finalAttrs: {
     hspell
   ];
 
+  patches = [
+    # This patch prevent libtool to fail with the following error:
+    # > libtool: link: unable to infer tagged configuration
+    # > libtool:   error: specify a tag with '--tag'
+    # Report and fix from https://bugs.gentoo.org/630072
+    ./fix-libtool-build.patch
+  ];
+
   meta = {
     description = "Generic spell checking library";
     homepage = "https://abiword.github.io/enchant";

--- a/pkgs/enchant/fix-libtool-build.patch
+++ b/pkgs/enchant/fix-libtool-build.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.in	2019-11-30 09:18:43.219061919 +0100
++++ b/src/Makefile.in	2019-11-30 09:18:52.418062147 +0100
+@@ -151,7 +151,7 @@
+ am__v_lt_0 = --silent
+ am__v_lt_1 =
+ libenchant_la_LINK = $(LIBTOOL) $(AM_V_lt) $(AM_LIBTOOLFLAGS) \
+-	$(LIBTOOLFLAGS) --mode=link $(OBJCLD) $(AM_OBJCFLAGS) \
++	$(LIBTOOLFLAGS) --tag=CC --mode=link $(OBJCLD) $(AM_OBJCFLAGS) \
+ 	$(OBJCFLAGS) $(libenchant_la_LDFLAGS) $(LDFLAGS) -o $@
+ AM_V_P = $(am__v_P_@AM_V@)
+ am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)


### PR DESCRIPTION
Adding the patch by default, it doesn't make any difference on Linux platforms, only for Darwin.

See: https://github.com/loophp/nix-shell/actions/runs/5477574995/jobs/9976841537

See: https://bugs.gentoo.org/630072