### PR TITLE
extensions: `inotify`: throw when used on `darwin` architecture

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -274,6 +274,12 @@ in
         ourPatches ++ upstreamPatches;
     });
 
+    inotify =
+      if pkgs.stdenv.isDarwin then
+        throw "php.extensions.inotify is not supported on Darwin, only on Linux."
+      else
+        prev.extensions.inotify;
+
     json =
       if lib.versionAtLeast prev.php.version "8.0" then
         throw "php.extensions.json is enabled by default in PHP >= 8.0."


### PR DESCRIPTION
Inotify requirements: https://www.php.net/manual/en/inotify.requirements.php

Upstream PR: https://github.com/NixOS/nixpkgs/pull/242015

~~Question: Is this PR needed once the upstream PR will be merged?~~ I don't think this PR will be needed once the upstream PR will be merged.