### PR TITLE
extensions: `mongodb`: fix extension version for php < 7

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -299,6 +299,19 @@ in
       else
         prev.extensions.memcached;
 
+    mongodb =
+      if lib.versionOlder prev.php.version "7.0" then
+        prev.extensions.mongodb.overrideAttrs (attrs: {
+          name = "mongodb-1.7.5";
+          version = "1.7.5";
+          src = pkgs.fetchurl {
+            url = "http://pecl.php.net/get/mongodb-1.7.5.tgz";
+            hash = "sha256-5IoHYYwK6L5igpmZG19IGGHIkaIlRKI2WmM2HMGBw3k=";
+          };
+        })
+      else
+        prev.extensions.mongodb;
+
     mssql =
       if lib.versionOlder prev.php.version "7.0" then
         prev.mkExtension {


### PR DESCRIPTION
See https://www.php.net/manual/en/mongodb.requirements.php

Also pushing an update upstream to update the extension at https://github.com/NixOS/nixpkgs/pull/242366