### PR TITLE
phpExtensions.igbinary: add support for PHP 5.6

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -232,6 +232,19 @@ in
         ];
     });
 
+    igbinary =
+      if lib.versionOlder prev.php.version "7.0" then
+        prev.extensions.igbinary.overrideAttrs (attrs: {
+          name = "igbinary-2.0.8";
+          version = "2.0.8";
+          src = pkgs.fetchurl {
+            url = "http://pecl.php.net/get/igbinary-2.0.8.tgz";
+            hash = "sha256-usurEXLgc7GFfcB6SGv9rKbWD77WeM4PSzfNAY71toA=";
+          };
+        })
+      else
+        prev.extensions.igbinary;
+
     intl = prev.extensions.intl.overrideAttrs (attrs: {
       doCheck = if lib.versionOlder prev.php.version "7.2" then false else attrs.doCheck or true;
       patches =


### PR DESCRIPTION
https://pecl.php.net/package-changelog.php?package=igbinary

Upstream PR to add support for PHP 8.3: https://github.com/NixOS/nixpkgs/pull/242900