### PR TITLE
phpExtensions.datadog_trace: fix builds on PHP 5.6

### DIFF
--- a/pkgs/extensions/datadog_trace/0.75.0.nix
+++ b/pkgs/extensions/datadog_trace/0.75.0.nix
@@ -1,0 +1,19 @@
+{ buildPecl, curl, lib, pcre2 }:
+
+buildPecl {
+  pname = "datadog_trace";
+  version = "0.75.0";
+  sha256 = "sha256-xgymzG9QBhLO/sBaEAfAVwPDB8PswB5Yq6yqXbyvAvw=";
+
+  buildInputs = [
+    curl
+    pcre2
+  ];
+
+  meta = {
+    description = "Datadog Tracing PHP Client";
+    homepage = "https://github.com/DataDog/dd-trace-php";
+    license = with lib.licenses; [ asl20 bsd3 ];
+    maintainers = lib.teams.php.members;
+  };
+}

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -95,14 +95,7 @@ in
       if lib.versionAtLeast prev.php.version "8.3" then
         throw "php.extensions.datadog_trace requires PHP version >= 5.6 and < 8.3"
       else if lib.versionOlder prev.php.version "7" then
-        prev.extensions.datadog_trace.overrideAttrs (attrs: {
-          name = "datadog_trace-0.75.0";
-          version = "0.75.0";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/datadog_trace-0.75.0.tgz";
-            hash = "sha256-xgymzG9QBhLO/sBaEAfAVwPDB8PswB5Yq6yqXbyvAvw=";
-          };
-        })
+        final.callPackage ./extensions/datadog_trace/0.75.0.nix { }
       else
         prev.extensions.datadog_trace;
 


### PR DESCRIPTION
Since the newest upstream version of `datadog_trace` uses Rust, we have to disable it in the override.

Is there a better way to do this ?

I don't like the fact that I had to copy the `nativeBuildInputs` from `build-pecl.nix`. Any clue on how to do this differently without duplicating informations?

This PR needs https://github.com/NixOS/nixpkgs/pull/243086