### PR TITLE
phpExtensions.grpc: disable on php56

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -234,14 +234,7 @@ in
 
     grpc =
       if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.grpc.overrideAttrs (attrs: {
-          name = "grpc-1.33.1";
-          version = "1.33.1";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/grpc-1.33.1.tgz";
-            hash = "sha256-qibrH7DWYhb3CRBdJgWopysgQHB20em7C9fLF6J3WCw=";
-          };
-        })
+        throw "php.extensions.grpc requires PHP version >= 7.0"
       else
         prev.extensions.grpc;
 


### PR DESCRIPTION
Is there a better way to let the user know that there are version of `grpc` that works on PHP 5.6 but we don't currently support it ?

I've been trying to compile the version 1.33.1 which is the latest `grpc` stable version for PHP 5.6, but I couldn't make it work (issue with abseil-cpp library). I guess there would be a way to fix this, but does it worth it ?