### PR TITLE
phpExtensions.pdlib: fix throw message typo, require PHP >= 7

### DIFF
--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -541,7 +541,7 @@ in
         throw "php.extensions.pcov requires PHP version >= 7.1.";
 
     pdlib = if lib.versionOlder prev.php.version "7.0" then
-        throw "php.extensions.pdlib requires PHP version >= 7.1."
+        throw "php.extensions.pdlib requires PHP version >= 7.0."
       else
         prev.extensions.pdlib;
 


### PR DESCRIPTION
Follow up of #279 