### PR TITLE
fix: builds on Darwin 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   build:
-    name: 'PHP ${{ matrix.php.branch }}'
-    runs-on: ubuntu-latest
+    name: "PHP ${{ matrix.php.branch }} on ${{ matrix.archs.arch }}"
+    runs-on: ${{ matrix.archs.os }}
     strategy:
       matrix:
         php:
@@ -26,13 +26,18 @@ jobs:
           - branch: '7.1'
           - branch: '7.0'
           - branch: '5.6'
+        archs:
+          [
+            { os: ubuntu-latest, arch: x86_64-linux },
+            { os: macOS-latest, arch: x86_64-darwin },
+          ]
       # We want to fix failures individually.
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: DeterminateSystems/nix-installer-action@v4
 
       - name: Set up Nix cache
         uses: cachix/cachix-action@v12
@@ -52,38 +57,38 @@ jobs:
           echo "attr=$attr" >> $GITHUB_OUTPUT
 
       - name: Build PHP
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-php
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-php
 
       - name: List extensions
         run: |
-          nix eval --json --impure --expr 'builtins.attrNames (import ./.).packages.x86_64-linux.${{ steps.params.outputs.attr }}.extensions'
+          nix eval --json --impure --expr 'builtins.attrNames (import ./.).packages.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}.extensions'
 
       - name: Build Imagick extension
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-imagick
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-imagick
 
       - name: Build Redis extension
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-redis
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-redis
 
       - name: Build Redis 3 extension
         if: ${{ steps.params.outputs.major < 8 }}
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-redis3
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-redis3
 
       - name: Build MySQL extension
         if: ${{ steps.params.outputs.major < 7 }}
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-mysql
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-mysql
 
       - name: Build Xdebug extension
         if: ${{ !(steps.params.outputs.major == 8 && steps.params.outputs.minor == 3) }}
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-xdebug
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-xdebug
 
       - name: Build Tidy extension
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-tidy
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-tidy
 
       - name: Check that composer PHAR works
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-composer-phar
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-composer-phar
 
       - name: Validate php.extensions.mysqli default unix socket path
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-mysqli-socket-path
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-mysqli-socket-path
 
       - name: Validate php.extensions.pdo_mysql default unix socket path
-        run: nix-build -A outputs.checks.x86_64-linux.${{ steps.params.outputs.attr }}-pdo_mysql-socket-path
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-pdo_mysql-socket-path

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
         run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-redis
 
       - name: Build Redis 3 extension
-        if: ${{ steps.params.outputs.major < 8 }}
+        if: ${{ steps.params.outputs.major < 8 && matrix.archs.arch == 'x86_64-linux' }}
         run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-redis3
 
       - name: Build MySQL extension

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -510,7 +510,7 @@ in
       buildInputs =
         let
           replaceOpenssl = pkg:
-            if pkg == pkgs.openssl && lib.versionOlder prev.php.version "8.1" then
+            if pkg.pname == "openssl" && lib.versionOlder prev.php.version "8.1" then
               pkgs.openssl_1_1.overrideAttrs (old: {
                 meta = builtins.removeAttrs old.meta [ "knownVulnerabilities" ];
               })

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -620,7 +620,10 @@ in
           version = "3.1.6";
           src = pkgs.fetchurl {
             url = "http://pecl.php.net/get/redis-3.1.6.tgz";
-            sha256 = "siknTNwUwi78Qf76ANtNxbsyqZfWgRJ4ZioEOnaqJgA=";
+            hash = "sha256-siknTNwUwi78Qf76ANtNxbsyqZfWgRJ4ZioEOnaqJgA=";
+          };
+          meta = attrs.meta // {
+            platforms = lib.platforms.linux;
           };
         })
       else


### PR DESCRIPTION
Since a week or two (_I can't really tell when_), it's not possible to build PHP < 8.1 on Darwin. This PR is to investigate why.

To test on Darwin:

0. Clone this repo: `git@github.com:fossar/nix-phps.git`
1. Apply the following patch: 
```diff
diff --git i/pkgs/package-overrides.nix w/pkgs/package-overrides.nix
index 6cd988d..1691c5e 100644
--- i/pkgs/package-overrides.nix
+++ w/pkgs/package-overrides.nix
@@ -507,17 +507,21 @@ in
         in
         ourPatches ++ upstreamPatches;
 
-      buildInputs =
-        let
-          replaceOpenssl = pkg:
-            if pkg == pkgs.openssl && lib.versionOlder prev.php.version "8.1" then
-              pkgs.openssl_1_1.overrideAttrs (old: {
-                meta = builtins.removeAttrs old.meta [ "knownVulnerabilities" ];
-              })
-            else
-              pkg;
-        in
-        builtins.map replaceOpenssl attrs.buildInputs;
+      buildInputs =let
+        a =
+          let
+            replaceOpenssl = pkg:
+              if (builtins.trace pkg.name pkg) == (builtins.trace pkgs.openssl.name pkgs.openssl) && lib.versionOlder prev.php.version "8.1" then

+                pkgs.openssl_1_1.overrideAttrs (old: {
+                  meta = builtins.removeAttrs old.meta [ "knownVulnerabilities" ];
+                })
+              else
+                pkg;
+          in
+            builtins.map replaceOpenssl attrs.buildInputs;
+        b = (lib.elemAt a 0).name;
+      in
+        builtins.trace b a;
     });
 
     openswoole =
```

2. Run: `nix build .#php74.extensions.openssl -L`
3. You should see: `openssl-1.1.1u`
