### PR TITLE
fix: php <= 7.4 libtool sha256

### DIFF
--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -39,7 +39,7 @@ let
               # https://github.com/php/php-src/commit/d016434ad33284dfaceb8d233351d34356566d7d
               (prev.pkgs.fetchpatch2 {
                 url = "https://github.com/php/php-src/commit/d016434ad33284dfaceb8d233351d34356566d7d.patch";
-                sha256 = "sha256-x0vEcoXNFeQi3re1TrK/Np9AH5dy3wf95xM08xCyGE0=";
+                sha256 = "sha256-Th1ZhC8t84MACxosoYud1LGDd5DtYe36Ctk1Ocjcu1s=";
                 includes = [
                   "build/libtool.m4"
                 ];


### PR DESCRIPTION
fixes https://github.com/fossar/nix-phps/issues/305

I tested it locally, everything was fine.

![2023-11-03_14-31](https://github.com/fossar/nix-phps/assets/70096720/4cdd57ee-30f2-4ac8-af57-9d43221f673d)
