### PR TITLE
ci: Update GitHub actions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Hopefully, this will fix broken `DeterminateSystems/update-flake-lock` due to Nix version incompatibility.
