### PR TITLE
php84: init at 8.4.0beta3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - branch: '8.4'
           - branch: '8.3'
           - branch: '8.2'
           - branch: '8.1'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following versions are currently available:
 - `php81`
 - `php82`
 - `php83`
+- `php84`
 
 There is also a `php` package which is the alias of the default PHP version in Nixpkgs.
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719468428,
-        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
+        "lastModified": 1724700889,
+        "narHash": "sha256-3aBLKOgLRGUnfu3KfN6uALk4e9wlu2YPg4QNxaHqHBI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
+        "rev": "79ed718bf5fa685c44ed4607c314527ff832e53f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
         };
       in rec {
         packages = {
-          inherit (pkgs) php php56 php70 php71 php72 php73 php74 php80 php81 php82 php83;
+          inherit (pkgs) php php56 php70 php71 php72 php73 php74 php80 php81 php82 php83 php84;
         };
 
         checks = import ./checks.nix {

--- a/pkgs/extensions/redis/3.nix
+++ b/pkgs/extensions/redis/3.nix
@@ -1,0 +1,26 @@
+{
+  buildPecl,
+  lib,
+  php,
+  fetchurl,
+}:
+
+buildPecl {
+  version = "3.1.6";
+  pname = "redis";
+
+  src = fetchurl {
+    url = "http://pecl.php.net/get/redis-3.1.6.tgz";
+    hash = "sha256-siknTNwUwi78Qf76ANtNxbsyqZfWgRJ4ZioEOnaqJgA=";
+  };
+
+  internalDeps = [ php.extensions.session ];
+
+  meta = {
+    description = "PHP extension for interfacing with Redis";
+    license = lib.licenses.php301;
+    platforms = lib.platforms.linux;
+    homepage = "https://github.com/phpredis/phpredis/";
+    maintainers = lib.teams.php.members;
+  };
+}

--- a/pkgs/extensions/redis/4.nix
+++ b/pkgs/extensions/redis/4.nix
@@ -1,0 +1,26 @@
+{
+  buildPecl,
+  lib,
+  php,
+  fetchurl,
+}:
+
+buildPecl {
+  version = "4.3.0";
+  pname = "redis";
+
+  src = fetchurl {
+    url = "http://pecl.php.net/get/redis-4.3.0.tgz";
+    hash = "sha256-wPBM7DSZYKhCtgkg+4pDNlbi5JTq7W5mM5fWcQKlG6I=";
+  };
+
+  internalDeps = [ php.extensions.session ];
+
+  meta = {
+    description = "PHP extension for interfacing with Redis";
+    license = lib.licenses.php301;
+    platforms = lib.platforms.unix;
+    homepage = "https://github.com/phpredis/phpredis/";
+    maintainers = lib.teams.php.members;
+  };
+}

--- a/pkgs/extensions/redis/6.0.nix
+++ b/pkgs/extensions/redis/6.0.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  buildPecl,
+  lib,
+  php,
+  fetchurl,
+}:
+
+buildPecl {
+  version = "6.0.2";
+  pname = "redis";
+
+  src = fetchurl {
+    url = "http://pecl.php.net/get/redis-6.0.2.tgz";
+    hash = "sha256-Aa7MsOFPiX/lbwUJvm5pkf8K1Fn5006V5FVtAmmbmgM=";
+  };
+
+  internalDeps = [
+    php.extensions.session
+    php.extensions.json
+  ];
+
+  env = lib.optionalAttrs (lib.versionOlder php.version "7.2" && stdenv.cc.isClang) {
+    NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-int-conversion";
+  };
+
+  meta = {
+    description = "PHP extension for interfacing with Redis";
+    license = lib.licenses.php301;
+    platforms = lib.platforms.unix;
+    homepage = "https://github.com/phpredis/phpredis/";
+    maintainers = lib.teams.php.members;
+  };
+}

--- a/pkgs/libxml2/2.12.nix
+++ b/pkgs/libxml2/2.12.nix
@@ -1,0 +1,73 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pkg-config,
+  autoreconfHook,
+  findXMLCatalogs,
+  libiconv,
+  icuSupport ? false,
+  icu,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxml2";
+  version = "2.12.9";
+
+  outputs = [
+    "bin"
+    "dev"
+    "out"
+  ];
+  outputMan = "bin";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor finalAttrs.version}/libxml2-${finalAttrs.version}.tar.xz";
+    hash = "sha256-WZEttTarVqOZZInqApl2jHvP/lcWnwI15/liqR9INZA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  propagatedBuildInputs = [
+    findXMLCatalogs
+  ] ++ lib.optionals stdenv.isDarwin [ libiconv ] ++ lib.optionals icuSupport [ icu ];
+
+  configureFlags = [
+    "--exec-prefix=${placeholder "dev"}"
+    (lib.withFeature icuSupport "icu")
+    "--without-python"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = (stdenv.hostPlatform == stdenv.buildPlatform) && stdenv.hostPlatform.libc != "musl";
+  preCheck = lib.optional stdenv.isDarwin ''
+    export DYLD_LIBRARY_PATH="$PWD/.libs:$DYLD_LIBRARY_PATH"
+  '';
+
+  preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''
+    MACOSX_DEPLOYMENT_TARGET=10.16
+  '';
+
+  postFixup = ''
+    moveToOutput bin/xml2-config "$dev"
+    moveToOutput lib/xml2Conf.sh "$dev"
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.gnome.org/GNOME/libxml2";
+    description = "XML parsing library for C";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [
+      eelco
+      jtojnar
+    ];
+    pkgConfigModules = [ "libxml-2.0" ];
+  };
+})

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -147,6 +147,9 @@ in
           "--with-libxml-dir=${pkgs.libxml2.dev}"
         ];
 
+      # Tests fail on Darwin for some reason.
+      doCheck = lib.versionOlder prev.php.version "7.4" -> pkgs.stdenv.isLinux;
+
       postPatch =
         lib.concatStringsSep "\n" [
           (attrs.postPatch or "")
@@ -725,6 +728,10 @@ in
           # Required to build on darwin.
           "--with-libxml-dir=${pkgs.libxml2.dev}"
         ];
+
+        # Tests fail on Darwin for some reason.
+        doCheck = lib.versionOlder prev.php.version "7.4" -> pkgs.stdenv.isLinux;
+
       });
 
     swoole =
@@ -749,6 +756,9 @@ in
           # Required to build on darwin.
           "--with-libxml-dir=${pkgs.libxml2.dev}"
         ];
+
+        # Tests fail on Darwin with older PHP versions for some reason.
+        doCheck = attrs.doCheck or true && (lib.versionOlder prev.php.version "7.4" -> pkgs.stdenv.isLinux);
       });
 
 
@@ -907,6 +917,9 @@ in
           # Required to build on darwin.
           "--with-libxml-dir=${pkgs.libxml2.dev}"
         ];
+
+        # Test tests/bug71536.phpt fails on Darwin with PHP 7.3 for some reason.
+        doCheck = attrs.doCheck or true && (lib.versions.majorMinor prev.php.version == "7.3" -> pkgs.stdenv.isLinux);
     });
 
     zip = prev.extensions.zip.overrideAttrs (attrs: {

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -713,17 +713,7 @@ in
 
     redis3 =
       if lib.versionOlder prev.php.version "8.0" then
-        prev.extensions.redis.overrideAttrs (attrs: {
-          name = "redis-3.1.6";
-          version = "3.1.6";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/redis-3.1.6.tgz";
-            hash = "sha256-siknTNwUwi78Qf76ANtNxbsyqZfWgRJ4ZioEOnaqJgA=";
-          };
-          meta = attrs.meta // {
-            platforms = lib.platforms.linux;
-          };
-        })
+        final.callPackage ./extensions/redis/3.nix { }
       else
         throw "php.extensions.redis requires PHP version < 8.0.";
 

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -835,7 +835,24 @@ in
 
     xdebug =
       # xdebug versions were determined using https://xdebug.org/docs/compat
-      if lib.versionAtLeast prev.php.version "8.0" then
+      if lib.versionAtLeast prev.php.version "8.4" then
+        prev.extensions.xdebug.overrideAttrs (attrs: {
+          name = "xdebug-3.4.0alpha1";
+          version = "3.4.0alpha1";
+          src = pkgs.fetchurl {
+            url = "https://xdebug.org/files/xdebug-3.4.0alpha1.tgz";
+            hash = "sha256-S4oizwlhom50uV+ToV6ctdWka8d2CKnAPb2YmWOytOc=";
+          };
+
+          patches = [
+            # Fix missing ZEND_EXIT
+            (pkgs.fetchpatch {
+              url = "https://github.com/xdebug/xdebug/commit/6ecd35f898e67cbe7f9257e7cb3a4c602a3dc8ec.patch";
+              hash = "sha256-IYc1KKPBYek4AXEijoM9RaTwp51J0Gz/CQ1HgmTct3Q=";
+            })
+          ];
+        })
+      else if lib.versionAtLeast prev.php.version "8.0" then
         prev.extensions.xdebug
       else if lib.versionAtLeast prev.php.version "7.2" then
         prev.extensions.xdebug.overrideAttrs (attrs: {

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -689,6 +689,8 @@ in
     redis =
       if lib.versionOlder prev.php.version "7.0" then
         final.callPackage ./extensions/redis/4.nix { }
+      else if lib.versionOlder prev.php.version "7.1" then
+        final.callPackage ./extensions/redis/6.0.nix { }
       else if lib.versionOlder prev.php.version "8.0" then
         prev.extensions.redis.overrideAttrs (attrs: {
           preConfigure =

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -120,19 +120,19 @@ in
                 "ext/dom/tests/bug80268.phpt"
               ];
             })
-          ] ++ lib.optionals (lib.versionOlder prev.php.version "7.3" && lib.versionAtLeast prev.php.version "7.1") [
+          ] ++ lib.optionals (lib.versionAtLeast prev.php.version "7.1" && lib.versionOlder prev.php.version "7.3") [
             # Patch rebased from https://github.com/php/php-src/commit/061058a9b1bbd90d27d97d79aebcf2b5029767b0
             # Fix PHP tests with libxml2 2.12
             ./patches/php71-libxml212-tests.patch
-          ] ++ lib.optionals (lib.versionOlder prev.php.version "7.4" && lib.versionAtLeast prev.php.version "7.3") [
+          ] ++ lib.optionals (lib.versionAtLeast prev.php.version "7.3" && lib.versionOlder prev.php.version "7.4") [
             # Patch rebased from https://github.com/php/php-src/commit/061058a9b1bbd90d27d97d79aebcf2b5029767b0
             # Fix PHP tests with libxml2 2.12
             ./patches/php73-libxml212-tests.patch
-          ] ++ lib.optionals (lib.versionOlder prev.php.version "8.1" && lib.versionAtLeast prev.php.version "7.4") [
+          ] ++ lib.optionals (lib.versionAtLeast prev.php.version "7.4" && lib.versionOlder prev.php.version "8.1") [
             # Patch rebased from https://github.com/php/php-src/commit/061058a9b1bbd90d27d97d79aebcf2b5029767b0
             # Fix PHP tests with libxml2 2.12
             ./patches/php74-libxml212-tests.patch
-          ] ++ lib.optionals (lib.versionOlder prev.php.version "8.2.14" && lib.versionAtLeast prev.php.version "8.1") [
+          ] ++ lib.optionals (lib.versionAtLeast prev.php.version "8.1" && lib.versionOlder prev.php.version "8.2.14") [
             # Patch rebased from https://github.com/php/php-src/commit/0a39890c967aa57225bb6bdf4821aff7a3a3c082
             # Fix compilation errors with libxml2 2.12
             ./patches/libxml-ext.patch
@@ -151,7 +151,7 @@ in
         lib.concatStringsSep "\n" [
           (attrs.postPatch or "")
 
-          (lib.optionalString (lib.versionOlder prev.php.version "7.4" && lib.versionAtLeast prev.php.version "7.3") ''
+          (lib.optionalString (lib.versionAtLeast prev.php.version "7.3" && lib.versionOlder prev.php.version "7.4") ''
             # 4cc261aa6afca2190b1b74de39c3caa462ec6f0b deletes this file but fetchpatch does not support deletions.
             rm ext/dom/tests/bug80268.phpt
           '')
@@ -161,7 +161,7 @@ in
             rm ext/dom/tests/bug43364.phpt
           '')
 
-          (lib.optionalString (lib.versionOlder prev.php.version "8.1" && lib.versionAtLeast prev.php.version "7.1") ''
+          (lib.optionalString (lib.versionAtLeast prev.php.version "7.1" && lib.versionOlder prev.php.version "8.1") ''
             # Removing tests failing with libxml2 (2.11.4) > 2.10.4
             rm ext/dom/tests/DOMDocument_loadXML_error2.phpt
             rm ext/dom/tests/DOMDocument_load_error2.phpt
@@ -774,7 +774,7 @@ in
             attrs.patches or [];
 
           ourPatches =
-            lib.optionals (lib.versionOlder prev.php.version "8.1" && lib.versionAtLeast prev.php.version "7.1") [
+            lib.optionals (lib.versionAtLeast prev.php.version "7.1" && lib.versionOlder prev.php.version "8.1") [
               # Fix GH-12633: sqlite3_defensive.phpt fails with sqlite 3.44.0
               # https://github.com/php/php-src/commit/2a4775d6a73e9f6d4fc8e7df6f052aa18790a8e9
               (pkgs.fetchpatch {

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -688,14 +688,7 @@ in
 
     redis =
       if lib.versionOlder prev.php.version "7.0" then
-        prev.extensions.redis.overrideAttrs (attrs: {
-          name = "redis-4.3.0";
-          version = "4.3.0";
-          src = pkgs.fetchurl {
-            url = "http://pecl.php.net/get/redis-4.3.0.tgz";
-            sha256 = "wPBM7DSZYKhCtgkg+4pDNlbi5JTq7W5mM5fWcQKlG6I=";
-          };
-        })
+        final.callPackage ./extensions/redis/4.nix { }
       else if lib.versionOlder prev.php.version "8.0" then
         prev.extensions.redis.overrideAttrs (attrs: {
           preConfigure =

--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -11,14 +11,14 @@ let
   _mkArgs =
     args:
 
-    {
-      inherit packageOverrides;
-
-      # For passing pcre2 to generic.nix.
+    let
       pcre2 =
         if prev.lib.versionAtLeast args.version "7.3"
         then prev.pcre2
         else prev.pcre;
+    in
+    {
+      inherit packageOverrides pcre2;
 
       phpAttrsOverrides =
         attrs:
@@ -108,10 +108,7 @@ let
 
           # Only pass these attributes if the package function actually expects them.
           prev.lib.filterAttrs (key: _v: builtins.hasAttr key prevArgs) {
-            pcre2 =
-              if prev.lib.versionAtLeast args.version "7.3"
-              then prev.pcre2
-              else prev.pcre;
+            inherit pcre2;
 
             # For passing pcre2 to stuff called with callPackage in php-packages.nix.
             pkgs =
@@ -120,10 +117,7 @@ let
                 prev.lib.makeScope
                   prev.newScope
                   (self: {
-                    pcre2 =
-                      if prev.lib.versionAtLeast args.version "7.3"
-                      then prev.pcre2
-                      else prev.pcre;
+                    inherit pcre2;
                   })
               );
           }

--- a/pkgs/phps.nix
+++ b/pkgs/phps.nix
@@ -164,4 +164,8 @@ in
   php83 = prev.php83.override {
     inherit packageOverrides;
   };
+
+  php84 = prev.php84.override {
+    inherit packageOverrides;
+  };
 }


### PR DESCRIPTION
- [x] mysqli socket regression test (`outputs.checks.x86_64-linux.php81-mysqli-socket-path`) fails, reportedly due to missing symbols:

    ```
    Warning: PHP Startup: Unable to load dynamic library '/nix/store/gv1fxy87wgndr0y023qphdq7l4r6idjr-php-mysqlnd-8.1.29/lib/php/extensions/mysqlnd.so' (tried: /nix/store/gv1fxy87wgndr0y023qphdq7l4r6idjr-php-mysqlnd-8.1.29/lib/php/extensions/mysqlnd.so (/nix/store/gv1fxy87wgndr0y023qphdq7l4r6idjr-php-mysqlnd-8.1.29/lib/php/extensions/mysqlnd.so: undefined symbol: compress), /nix/store/m86afannv5mjvyh4icmmh15799lacy4k-php-8.1.29/lib/php/extensions//nix/store/gv1fxy87wgndr0y023qphdq7l4r6idjr-php-mysqlnd-8.1.29/lib/php/extensions/mysqlnd.so.so (/nix/store/m86afannv5mjvyh4icmmh15799lacy4k-php-8.1.29/lib/php/extensions//nix/store/gv1fxy87wgndr0y023qphdq7l4r6idjr-php-mysqlnd-8.1.29/lib/php/extensions/mysqlnd.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0

    Warning: PHP Startup: Unable to load dynamic library '/nix/store/sfv14v1f7cbd538wj3mccqak8ccnga7p-php-mysqli-8.1.29/lib/php/extensions/mysqli.so' (tried: /nix/store/sfv14v1f7cbd538wj3mccqak8ccnga7p-php-mysqli-8.1.29/lib/php/extensions/mysqli.so (/nix/store/sfv14v1f7cbd538wj3mccqak8ccnga7p-php-mysqli-8.1.29/lib/php/extensions/mysqli.so: undefined symbol: mysqlnd_global_stats), /nix/store/m86afannv5mjvyh4icmmh15799lacy4k-php-8.1.29/lib/php/extensions//nix/store/sfv14v1f7cbd538wj3mccqak8ccnga7p-php-mysqli-8.1.29/lib/php/extensions/mysqli.so.so (/nix/store/m86afannv5mjvyh4icmmh15799lacy4k-php-8.1.29/lib/php/extensions//nix/store/sfv14v1f7cbd538wj3mccqak8ccnga7p-php-mysqli-8.1.29/lib/php/extensions/mysqli.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
    ```
  - not sure why, nothing suspicious in `git log -p 1e3deb3d8a86a870d925760db1a5adecc64d329d...5de1564aed415bf9d0f281461babc2d101dd49ff -- '**php**'`
  - tried comparing `mysqlnd.so` from known good Nixpkgs version using diffoscope but the `compress` symbol appears to be present in both
- [x] xdebug does not build with PHP 8.4 – we will need to switch to 3.4.0alpha1
- [x] redis does not build with PHP 8.4 https://github.com/NixOS/nixpkgs/pull/336912
- [x] ~~libxml2 patch needs backport https://github.com/NixOS/nixpkgs/pull/334411~~
    Decided to just vendor an older version of libxml2 since backporting the patche to an older PHP version would be too much work and breaks other stuff:

    > On PHP 8.0, setting `DOMDocument::$encoding` to `null` as is done by `bug77569.phpt` will coerce the property to an empty string.
    > Before libxml2 2.13, `xmlFindCharEncodingHandler('')` would return `null` but 2.13 changed it to return a pointer to an existing handler.
    > As a result setting the encoding in `bug77569.phpt` would not throw an exception and, consequently, the test would fail to match the output.
    > This patch makes it so that trying to set the `encoding` property to `null` throw “Invalid document encoding” error straigth away.
    > Unfortunately, in PHP 8.0, that error, for some reason, races ahead the exception thrown in `__toString` method of an object that is set as `encoding`.
    > This breaks the `toString_exceptions.phpt`.
    > This bug appears to be fixed in PHP 8.1.