### PR TITLE
php7[01234].extension.decimal: Override decimal to allow use in PHP 7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,6 +98,10 @@ jobs:
       - name: Build Tidy extension
         run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-tidy
 
+      - name: Build Decimal extension
+        if: ${{ steps.params.outputs.major >= 7 }}
+        run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-decimal
+
       - name: Check that composer PHAR works
         run: nix-build -A outputs.checks.${{ matrix.archs.arch }}.${{ steps.params.outputs.attr }}-composer-phar
 

--- a/checks.nix
+++ b/checks.nix
@@ -53,6 +53,12 @@ let
       drv = { php, ... }: php.extensions.tidy;
     };
 
+    decimal = {
+      description = "Build Decimal extension";
+      enabled = { php, lib, ... }: lib.versionAtLeast php.version "7";
+      drv = { php, ... }: php.extensions.decimal;
+    };
+
     composer-phar = {
       description = "Check that composer PHAR works";
       drv =

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -104,6 +104,16 @@ in
       else
         prev.extensions.datadog_trace;
 
+    decimal =
+      if lib.versionOlder prev.php.version "7.0" then
+        throw "php.extensions.decimal requires PHP version >= 7.0"
+      else if lib.versionOlder prev.php.version "8.0" then
+        prev.extensions.decimal.overrideAttrs (attrs: {
+          preConfigure = attrs.preConfigure or "" + linkInternalDeps [ final.extensions.json ];
+        })
+      else
+        prev.extensions.decimal;
+
     dom = prev.extensions.dom.overrideAttrs (attrs: {
       patches =
         let

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -110,6 +110,12 @@ in
       else if lib.versionOlder prev.php.version "8.0" then
         prev.extensions.decimal.overrideAttrs (attrs: {
           preConfigure = attrs.preConfigure or "" + linkInternalDeps [ final.extensions.json ];
+
+          env = mergeEnv attrs {
+            NIX_CFLAGS_COMPILE = lib.optionals (lib.versionOlder prev.php.version "7.4") [
+              "-Wno-incompatible-${lib.optionalString isClang "function-"}pointer-types"
+            ];
+          };
         })
       else
         prev.extensions.decimal;


### PR DESCRIPTION
[“decimal”](https://php-decimal.github.io) is a PHP extension [I added recently to Nixpkgs in this PR](https://github.com/NixOS/nixpkgs/pull/378564) with the aid of @jtojnar. Here I patch it to make it work for PHP 7, as it requires the JSON extension [which wasn't included in PHP until version 8](https://www.php.net/manual/en/json.installation.php). They also helped me get this working in issue #399.

This PR will have to wait until `flake.lock` is updated, though.