### PR TITLE
fix: remove patch for `ctype` extension

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744502386,
-        "narHash": "sha256-QAd1L37eU7ktL2WeLLLTmI6P9moz9+a/ONO8qNBYJgM=",
+        "lastModified": 1744868846,
+        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6db44a8daa59c40ae41ba6e5823ec77fe0d2124",
+        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
         "type": "github"
       },
       "original": {

--- a/pkgs/package-overrides.nix
+++ b/pkgs/package-overrides.nix
@@ -96,6 +96,15 @@ in
         attrs.preConfigure or "" + linkInternalDeps deps;
     });
 
+    ctype = prev.extensions.ctype.overrideAttrs (attrs: {
+      postPatch = removeLines (lib.optionals
+        (lib.versionOlder prev.php.version "8.2" && pkgs.stdenv.isDarwin)
+        [
+          "rm ext/ctype/tests/lc_ctype_inheritance.phpt"
+        ]
+      ) attrs.postPatch;
+    });
+
     datadog_trace =
       if lib.versionAtLeast prev.php.version "8.3" then
         throw "php.extensions.datadog_trace requires PHP version >= 5.6 and < 8.3"


### PR DESCRIPTION
Patch introduced in https://github.com/NixOS/nixpkgs/pull/398521