### PR TITLE
ci: Switch to `cachix/install-nix-action`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v19
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Nix cache
         uses: cachix/cachix-action@v16

--- a/.github/workflows/upgrade-flakes.yaml
+++ b/.github/workflows/upgrade-flakes.yaml
@@ -12,7 +12,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v19
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v27


### PR DESCRIPTION
DetSys installer is dropping upstream Nix support:
https://determinate.systems/blog/installer-dropping-upstream/

We could also use `nixbuild/nix-quick-install-action` but that uses single-user installation,
which does not support sandboxing on Darwin:
https://discourse.nixos.org/t/which-github-nix-installer-action-is-faster/25878/10
