### PR TITLE
.github/editorconfig-checks: Update editorconfig-checker 2.7.0 → 3.7.0

### DIFF
--- a/.github/workflows/editorconfig-checks.yaml
+++ b/.github/workflows/editorconfig-checks.yaml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check files for EditorConfig compliance
-        uses: editorconfig-checker/action-editorconfig-checker@6245a824737d548cb0eb2b678a81afeaf780ce1e # untagged main
+        uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
         with:
           version: 2.7.0

--- a/.github/workflows/editorconfig-checks.yaml
+++ b/.github/workflows/editorconfig-checks.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Check files for EditorConfig compliance
         uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
         with:
-          version: 2.7.0
+          version: v3.7.0


### PR DESCRIPTION

Initially, we pinned it to commit in 2d5d6068d955170a5cb034eb4db1f0a2023ea8e4
to work around a bug but that is no longer necessary.

Let’s reduce the bump frequency by tracking releases again.

Just dependency updates.
https://github.com/editorconfig-checker/action-editorconfig-checker/compare/6245a824737d548cb0eb2b678a81afeaf780ce1e...v2.2.0

While at it, let’s also update the pinned checker version:
https://github.com/editorconfig-checker/editorconfig-checker/compare/2.7.0...v3.7.0
